### PR TITLE
fix: Ensure tools handle parameters passed post-creation correctly

### DIFF
--- a/crewai_tools/tools/code_docs_search_tool/code_docs_search_tool.py
+++ b/crewai_tools/tools/code_docs_search_tool/code_docs_search_tool.py
@@ -57,4 +57,4 @@ class CodeDocsSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/csv_search_tool/csv_search_tool.py
+++ b/crewai_tools/tools/csv_search_tool/csv_search_tool.py
@@ -57,4 +57,4 @@ class CSVSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/directory_search_tool/directory_search_tool.py
+++ b/crewai_tools/tools/directory_search_tool/directory_search_tool.py
@@ -57,4 +57,4 @@ class DirectorySearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/docx_search_tool/docx_search_tool.py
+++ b/crewai_tools/tools/docx_search_tool/docx_search_tool.py
@@ -63,4 +63,4 @@ class DOCXSearchTool(RagTool):
         docx = kwargs.get("docx")
         if docx is not None:
             self.add(docx)
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/github_search_tool/github_search_tool.py
+++ b/crewai_tools/tools/github_search_tool/github_search_tool.py
@@ -68,4 +68,4 @@ class GithubSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/json_search_tool/json_search_tool.py
+++ b/crewai_tools/tools/json_search_tool/json_search_tool.py
@@ -57,4 +57,4 @@ class JSONSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/mdx_seach_tool/mdx_search_tool.py
+++ b/crewai_tools/tools/mdx_seach_tool/mdx_search_tool.py
@@ -57,4 +57,4 @@ class MDXSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/pg_seach_tool/pg_search_tool.py
+++ b/crewai_tools/tools/pg_seach_tool/pg_search_tool.py
@@ -41,4 +41,4 @@ class PGSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/txt_search_tool/txt_search_tool.py
+++ b/crewai_tools/tools/txt_search_tool/txt_search_tool.py
@@ -57,4 +57,4 @@ class TXTSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/website_search/website_search_tool.py
+++ b/crewai_tools/tools/website_search/website_search_tool.py
@@ -57,4 +57,4 @@ class WebsiteSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/xml_search_tool/xml_search_tool.py
+++ b/crewai_tools/tools/xml_search_tool/xml_search_tool.py
@@ -57,4 +57,4 @@ class XMLSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/youtube_channel_search_tool/youtube_channel_search_tool.py
+++ b/crewai_tools/tools/youtube_channel_search_tool/youtube_channel_search_tool.py
@@ -60,4 +60,4 @@ class YoutubeChannelSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)

--- a/crewai_tools/tools/youtube_video_search_tool/youtube_video_search_tool.py
+++ b/crewai_tools/tools/youtube_video_search_tool/youtube_video_search_tool.py
@@ -57,4 +57,4 @@ class YoutubeVideoSearchTool(RagTool):
         search_query: str,
         **kwargs: Any,
     ) -> Any:
-        return super()._run(query=search_query)
+        return super()._run(query=search_query, **kwargs)


### PR DESCRIPTION
- Fixed an issue where multiple RagTool based tools failed to function if parameters were provided after tool creation.
- Updated tools to correctly process source file/URL passed by the agent post-creation as per documentation.

Closes[ #<47>](https://github.com/joaomdmoura/crewAI-tools/issues/47)