### PR TITLE
Limit PDF search results to the provided PDF (IF a PDF is provided)

### DIFF
--- a/crewai_tools/adapters/pdf_embedchain_adapter.py
+++ b/crewai_tools/adapters/pdf_embedchain_adapter.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from embedchain import App
+
+from crewai_tools.tools.rag.rag_tool import Adapter
+
+
+class EmbedchainAdapter(Adapter):
+    embedchain_app: App
+    summarize: bool = False
+
+    def query(self, question: str) -> str:
+        result, sources = self.embedchain_app.query(
+            question, citations=True, dry_run=(not self.summarize)
+        )
+        if self.summarize:
+            return result
+        return "\n\n".join([source[0] for source in sources])
+
+    def add(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        self.embedchain_app.add(*args, **kwargs)

--- a/crewai_tools/adapters/pdf_embedchain_adapter.py
+++ b/crewai_tools/adapters/pdf_embedchain_adapter.py
@@ -1,17 +1,23 @@
-from typing import Any
+from typing import Any, Optional
 
 from embedchain import App
 
 from crewai_tools.tools.rag.rag_tool import Adapter
 
 
-class EmbedchainAdapter(Adapter):
+class PDFEmbedchainAdapter(Adapter):
     embedchain_app: App
     summarize: bool = False
+    src: Optional[str] = None
 
     def query(self, question: str) -> str:
+        where = (
+            {"app_id": self.embedchain_app.config.id, "source": self.src}
+            if self.src
+            else None
+        )
         result, sources = self.embedchain_app.query(
-            question, citations=True, dry_run=(not self.summarize)
+            question, citations=True, dry_run=(not self.summarize), where=where
         )
         if self.summarize:
             return result
@@ -22,4 +28,5 @@ class EmbedchainAdapter(Adapter):
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        self.src = args[0] if args else None
         self.embedchain_app.add(*args, **kwargs)


### PR DESCRIPTION
See: https://github.com/joaomdmoura/crewAI-tools/issues/63

Currently, when a PDF file-path is passed into the PDFSearchTool, the results returned from the PDFSearchTool are not limited to the passed-in PDF, and will return the top relevant information matching the search tool's query, from the vector database, regardless of which PDF was passed into the tool.

This pull request fixes that.

The scope of the impact of this change is limited by creating a PDF embedchain adapter which is specific to the PDF search tool, and which is nearly identical to embedchain adapter, with only a few changes. Namely:

- a pdf "src" is added to the adapter when the pdf is added to the vector database in the add() method
- a where clause is created to filter the results queried from the vector database to include only those which actually came from the provided PDF

As a follow up note: this could probably be implemented differently, by simply changing the functionality of the original embedchain_adapter.py file. I would be happy to do so if y'all think that is a better approach ☺️  