### PR TITLE
arguments descriptions added to tool description

### DIFF
--- a/crewai_tools/tools/base_tool.py
+++ b/crewai_tools/tools/base_tool.py
@@ -86,16 +86,16 @@ class BaseTool(BaseModel, ABC):
             )
 
     def _generate_description(self):
-            args = []
-            args_description = []
-            for arg, attribute in self.args_schema.schema()["properties"].items():
-                if "type" in attribute:
-                    args.append(f"{arg}: '{attribute['type']}'")
-                if "description" in attribute:
-                    args_description.append(f"{arg}: '{attribute['description']}'")
+        args = []
+        args_description = []
+        for arg, attribute in self.args_schema.schema()["properties"].items():
+            if "type" in attribute:
+                args.append(f"{arg}: '{attribute['type']}'")
+            if "description" in attribute:
+                args_description.append(f"{arg}: '{attribute['description']}'")
 
-            description = self.description.replace("\n", " ")
-            self.description = f"{self.name}({', '.join(args)}) - {description} {', '.join(args_description)}"
+        description = self.description.replace("\n", " ")
+        self.description = f"{self.name}({', '.join(args)}) - {description} {', '.join(args_description)}"
 
 
 class Tool(BaseTool):

--- a/crewai_tools/tools/base_tool.py
+++ b/crewai_tools/tools/base_tool.py
@@ -86,13 +86,16 @@ class BaseTool(BaseModel, ABC):
             )
 
     def _generate_description(self):
-        args = []
-        for arg, attribute in self.args_schema.schema()["properties"].items():
-            if "type" in attribute:
-                args.append(f"{arg}: '{attribute['type']}'")
+            args = []
+            args_description = []
+            for arg, attribute in self.args_schema.schema()["properties"].items():
+                if "type" in attribute:
+                    args.append(f"{arg}: '{attribute['type']}'")
+                if "description" in attribute:
+                    args_description.append(f"{arg}: '{attribute['description']}'")
 
-        description = self.description.replace("\n", " ")
-        self.description = f"{self.name}({', '.join(args)}) - {description}"
+            description = self.description.replace("\n", " ")
+            self.description = f"{self.name}({', '.join(args)}) - {description} {', '.join(args_description)}"
 
 
 class Tool(BaseTool):


### PR DESCRIPTION
The agent doesn't recieve descriptions of the tools arguments. This PR added the args description to tool description so agent will know how to use them.