### PR TITLE
[Bug] Improvements on default values and timeout description

### DIFF
--- a/crewai_tools/tools/firecrawl_crawl_website_tool/firecrawl_crawl_website_tool.py
+++ b/crewai_tools/tools/firecrawl_crawl_website_tool/firecrawl_crawl_website_tool.py
@@ -26,6 +26,11 @@ class FirecrawlCrawlWebsiteTool(BaseTool):
         self.firecrawl = FirecrawlApp(api_key=api_key)
 
     def _run(self, url: str, crawler_options: Optional[Dict[str, Any]] = None, page_options: Optional[Dict[str, Any]] = None):
+        if (crawler_options is None):
+            crawler_options = {}
+        if (page_options is None):
+            page_options = {}
+
         options = {
             "crawlerOptions": crawler_options,
             "pageOptions": page_options

--- a/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
+++ b/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
@@ -6,7 +6,7 @@ class FirecrawlScrapeWebsiteToolSchema(BaseModel):
     url: str = Field(description="Website URL")
     page_options: Optional[Dict[str, Any]] = Field(default=None, description="Options for page scraping")
     extractor_options: Optional[Dict[str, Any]] = Field(default=None, description="Options for data extraction")
-    timeout: Optional[int] = Field(default=None, description="Timeout for the scraping operation")
+    timeout: Optional[int] = Field(default=None, description="Timeout in milliseconds for the scraping operation. The default value is 30000.")
 
 class FirecrawlScrapeWebsiteTool(BaseTool):
     name: str = "Firecrawl web scrape tool"
@@ -27,6 +27,13 @@ class FirecrawlScrapeWebsiteTool(BaseTool):
         self.firecrawl = FirecrawlApp(api_key=api_key)
 
     def _run(self, url: str, page_options: Optional[Dict[str, Any]] = None, extractor_options: Optional[Dict[str, Any]] = None, timeout: Optional[int] = None):
+        if page_options is None:
+            page_options = {}
+        if extractor_options is None:
+            extractor_options = {}
+        if timeout is None:
+            timeout = 30000
+
         options = {
             "pageOptions": page_options,
             "extractorOptions": extractor_options,

--- a/crewai_tools/tools/firecrawl_search_tool/firecrawl_search_tool.py
+++ b/crewai_tools/tools/firecrawl_search_tool/firecrawl_search_tool.py
@@ -26,6 +26,11 @@ class FirecrawlSearchTool(BaseTool):
         self.firecrawl = FirecrawlApp(api_key=api_key)
 
     def _run(self, query: str, page_options: Optional[Dict[str, Any]] = None, result_options: Optional[Dict[str, Any]] = None):
+        if (page_options is None):
+            page_options = {}
+        if (result_options is None):
+            result_options = {}
+
         options = {
             "pageOptions": page_options,
             "resultOptions": result_options


### PR DESCRIPTION
Customers were encountering the following error from the agent:

```
I encountered an error while trying to use the tool. This was the error: argument of type 'NoneType' is not iterable.
 Tool Firecrawl web scrape tool accepts these inputs: Firecrawl web scrape tool(url: 'string', page_options: 'object', extractor_options: 'object', timeout: 'integer') - Scrape webpages url using Firecrawl and return the contents url: 'Website URL', page_options: 'Options for page scraping', extractor_options: 'Options for data extraction', timeout: 'Timeout for the scraping operation'
 ```
 
I've added some default values and better description for timeout for fixing this issue.