### PR TITLE
Fix NL2SQL pydantic version conflict

### DIFF
--- a/crewai_tools/tools/nl2sql/nl2sql_tool.py
+++ b/crewai_tools/tools/nl2sql/nl2sql_tool.py
@@ -1,12 +1,11 @@
 from typing import Any, Union
 
 from ..base_tool import BaseTool
-from pydantic import Field
+from pydantic import BaseModel, Field
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
-from typing import Optional, Type, Any
-from pydantic.v1 import BaseModel
+from typing import Type, Any
 
 class NL2SQLToolInput(BaseModel):
     sql_query: str = Field(


### PR DESCRIPTION
got this when trying it

```
...
  File "/home/thiago/.cache/pypoetry/virtualenvs/data-analyst-5pqohAtO-py3.10/lib/python3.10/site-packages/pydantic/v1/schema.py", line 995, in encode_default
    return pydantic_encoder(dft)
  File "/home/thiago/.cache/pypoetry/virtualenvs/data-analyst-5pqohAtO-py3.10/lib/python3.10/site-packages/pydantic/v1/json.py", line 90, in pydantic_encoder
    raise TypeError(f"Object of type '{obj.__class__.__name__}' is not JSON serializable")
TypeError: Object of type 'FieldInfo' is not JSON serializable
```

possibly a version conflict due to getting BaseModel from v1
using a copy of the tool, with the fix, the issue has gone