### PR TITLE
Fixing errors of the File Writer tool

### DIFF
--- a/crewai_tools/tools/file_writer_tool/file_writer_tool.py
+++ b/crewai_tools/tools/file_writer_tool/file_writer_tool.py
@@ -6,10 +6,10 @@ from distutils.util import strtobool
 
 
 class FileWriterToolInput(BaseModel):
-    filename: str
-    content: str
+    filename: str 
     directory: Optional[str] = "./"
     overwrite: str = "False"
+    content: str
     
 class FileWriterTool(BaseTool):
     name: str = "File Writer Tool"

--- a/crewai_tools/tools/file_writer_tool/file_writer_tool.py
+++ b/crewai_tools/tools/file_writer_tool/file_writer_tool.py
@@ -1,16 +1,17 @@
 import os
-from typing import Any, Type
+from typing import Any, Optional, Type
 from pydantic import BaseModel
-from crewai_tools import BaseTool
+from ..base_tool import BaseTool
 from distutils.util import strtobool
+
 
 class FileWriterToolInput(BaseModel):
     filename: str
     content: str
-    directory: str = "./"
+    directory: Optional[str] = "./"
     overwrite: str = "False"
     
-class FileWriterTool2(BaseTool):
+class FileWriterTool(BaseTool):
     name: str = "File Writer Tool"
     description: str = (
         "A tool to write content to a specified file. Accepts filename, content, and optionally a directory path and overwrite flag as input."

--- a/crewai_tools/tools/file_writer_tool/file_writer_tool.py
+++ b/crewai_tools/tools/file_writer_tool/file_writer_tool.py
@@ -1,19 +1,16 @@
 import os
-from typing import Any, Optional, Type
-
+from typing import Any, Type
 from pydantic import BaseModel
-
-from ..base_tool import BaseTool
-
+from crewai_tools import BaseTool
+from distutils.util import strtobool
 
 class FileWriterToolInput(BaseModel):
     filename: str
     content: str
-    directory: Optional[str] = None
-    overwrite: bool = False
-
-
-class FileWriterTool(BaseTool):
+    directory: str = "./"
+    overwrite: str = "False"
+    
+class FileWriterTool2(BaseTool):
     name: str = "File Writer Tool"
     description: str = (
         "A tool to write content to a specified file. Accepts filename, content, and optionally a directory path and overwrite flag as input."
@@ -23,11 +20,14 @@ class FileWriterTool(BaseTool):
     def _run(self, **kwargs: Any) -> str:
         try:
             # Create the directory if it doesn't exist
-            if kwargs["directory"] and not os.path.exists(kwargs["directory"]):
+            if kwargs.get("directory") and not os.path.exists(kwargs["directory"]):
                 os.makedirs(kwargs["directory"])
 
             # Construct the full path
-            filepath = os.path.join(kwargs["directory"] or "", kwargs["filename"])
+            filepath = os.path.join(kwargs.get("directory") or "", kwargs["filename"])
+            
+            # Convert overwrite to boolean
+            kwargs["overwrite"] = bool(strtobool(kwargs["overwrite"]))
 
             # Check if file exists and overwrite is not allowed
             if os.path.exists(filepath) and not kwargs["overwrite"]:
@@ -42,5 +42,7 @@ class FileWriterTool(BaseTool):
             return (
                 f"File {filepath} already exists and overwrite option was not passed."
             )
+        except KeyError as e:
+            return f"An error occurred while accessing key: {str(e)}"
         except Exception as e:
             return f"An error occurred while writing to the file: {str(e)}"


### PR DESCRIPTION
- Fixed a KeyError caused by invalid access to kwargs dictionary key "directory" when no "directory" input was provided (kwargs["directory"]), it was replaced with the get() method to cover both use cases.
![image](https://github.com/user-attachments/assets/f613133a-2950-4a9c-87fe-f35d63237cc4)

- The agent had trouble providing a correctly formatted input for the overwrite variable and would get stuck on the following error
![image](https://github.com/user-attachments/assets/ad2845cc-3e4c-434d-86be-25da345738ee)
Fixed it by changing the variable to string and converting it to boolean within the method, shows better behavior and resilience when used by agents.

- For content on the longer side, the agents tend to forget context when filling the rest of the arguments or closing the dictionary properly, changing the order of the arguments - placing 'content' last - significantly improved behavior.


