### PR TITLE
fix: web scraper concatenate words

### DIFF
--- a/crewai_tools/tools/scrape_website_tool/scrape_website_tool.py
+++ b/crewai_tools/tools/scrape_website_tool/scrape_website_tool.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Any, Optional, Type
 
 import requests
@@ -67,7 +68,6 @@ class ScrapeWebsiteTool(BaseTool):
         page.encoding = page.apparent_encoding
         parsed = BeautifulSoup(page.text, "html.parser")
 
-        text = parsed.get_text()
-        text = "\n".join([i for i in text.split("\n") if i.strip() != ""])
-        text = " ".join([i for i in text.split(" ") if i.strip() != ""])
+        text = parsed.get_text(" ")
+        text = re.sub('\s+', ' ', text)
         return text

--- a/crewai_tools/tools/scrape_website_tool/scrape_website_tool.py
+++ b/crewai_tools/tools/scrape_website_tool/scrape_website_tool.py
@@ -69,5 +69,6 @@ class ScrapeWebsiteTool(BaseTool):
         parsed = BeautifulSoup(page.text, "html.parser")
 
         text = parsed.get_text(" ")
-        text = re.sub('\s+', ' ', text)
+        text = re.sub('[ \t]+', ' ', text)
+        text = re.sub('\\s+\n\\s+', '\n', text)
         return text


### PR DESCRIPTION
Fixes issue when web scraper concatenate words:

before: 
- her**eQ**uestio**nS**elected Optio**nP**oints Awarde**dQ**uestion - Use cas**eS**elected Option -Selected Optio**nP**oints -Points Awarde**dQ**uestion

after: 
- here Question Selected Option Points Awarded Question - Use case Selected Option - Selected Option Points - Points Awarded Question

Test code:

```python
from crewai_tools import ScrapeWebsiteTool

tool = ScrapeWebsiteTool(website_url='https://www.crewai.com/')
text = tool.run()
print(text)
```