### PR TITLE
fix: correct variable name typo in exa_base_tool

### DIFF
--- a/crewai_tools/tools/exa_tools/exa_base_tool.py
+++ b/crewai_tools/tools/exa_tools/exa_base_tool.py
@@ -28,10 +28,10 @@ class EXABaseTool(BaseTool):
     }
 
     def _parse_results(self, results):
-        stirng = []
+        string = []
         for result in results:
             try:
-                stirng.append(
+                string.append(
                     "\n".join(
                         [
                             f"Title: {result['title']}",
@@ -43,7 +43,7 @@ class EXABaseTool(BaseTool):
                     )
                 )
             except KeyError:
-                next
+                continue
 
-        content = "\n".join(stirng)
+        content = "\n".join(string)
         return f"\nSearch results: {content}\n"


### PR DESCRIPTION
This PR fixes a variable typo in the typo in exa_base_tool