### PR TITLE
Enabled connection to docker daemon with manual setting of docker base url for code interpreter tool. (Issue #1555) 

### DIFF
--- a/crewai_tools/tools/code_interpreter_tool/README.md
+++ b/crewai_tools/tools/code_interpreter_tool/README.md
@@ -38,3 +38,16 @@ Agent(
     tools=[CodeInterpreterTool(user_dockerfile_path="<Dockerfile_path>")],
 )
 ```
+
+If it is difficult to connect to docker daemon automatically (especially for macOS users), you can do this to setup docker host manually
+
+```python 
+from crewai_tools import CodeInterpreterTool
+
+Agent(
+    ...
+    tools=[CodeInterpreterTool(user_docker_base_url="<Docker Host Base Url>",
+        user_dockerfile_path="<Dockerfile_path>")],
+)
+
+```

--- a/crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py
+++ b/crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py
@@ -28,6 +28,7 @@ class CodeInterpreterTool(BaseTool):
     default_image_tag: str = "code-interpreter:latest"
     code: Optional[str] = None
     user_dockerfile_path: Optional[str] = None
+    user_docker_base_url: Optional[str] = None 
     unsafe_mode: bool = False
 
     @staticmethod
@@ -39,7 +40,7 @@ class CodeInterpreterTool(BaseTool):
         """
         Verify if the Docker image is available. Optionally use a user-provided Dockerfile.
         """
-        client = docker.from_env()
+        client = docker.from_env() if self.user_docker_base_url != None else docker.DockerClient(base_url=self.user_docker_base_url)
 
         try:
             client.images.get(self.default_image_tag)

--- a/crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py
+++ b/crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py
@@ -40,7 +40,7 @@ class CodeInterpreterTool(BaseTool):
         """
         Verify if the Docker image is available. Optionally use a user-provided Dockerfile.
         """
-        client = docker.from_env() if self.user_docker_base_url != None else docker.DockerClient(base_url=self.user_docker_base_url)
+        client = docker.from_env() if self.user_docker_base_url == None else docker.DockerClient(base_url=self.user_docker_base_url)
 
         try:
             client.images.get(self.default_image_tag)


### PR DESCRIPTION
Goal is to avoid the error: CodeInterpreterTool Error while fetching server API version. 
See issue [#1555 ](https://github.com/crewAIInc/crewAI/issues/1555)crewai. 

solution code: 

```python 
from crewai_tools import CodeInterpreterTool

Agent(
    ...
    tools=[CodeInterpreterTool(user_docker_base_url="<Docker Host Base Url>",
        user_dockerfile_path="<Dockerfile_path>")],
)
```