### PR TITLE
fix: fix pydantic validation error

### DIFF
--- a/crewai_tools/tools/llamaindex_tool/llamaindex_tool.py
+++ b/crewai_tools/tools/llamaindex_tool/llamaindex_tool.py
@@ -18,6 +18,10 @@ class LlamaIndexTool(BaseTool):
         from llama_index.core.tools import BaseTool as LlamaBaseTool
 
         tool = cast(LlamaBaseTool, self.llama_index_tool)
+
+        if self.result_as_answer:
+            return tool(*args, **kwargs).content
+
         return tool(*args, **kwargs)
 
     @classmethod


### PR DESCRIPTION
- When passing result_as_answer=True, it will return ToolOutput so it won't pass pydantic validation as a string.

- Get content of ToolOutput before return.