### PR TITLE
Feat(SeleniumScrapingTool): Provide capability to return HTML

### DIFF
--- a/crewai_tools/tools/selenium_scraping_tool/README.md
+++ b/crewai_tools/tools/selenium_scraping_tool/README.md
@@ -31,3 +31,4 @@ tool = SeleniumScrapingTool(website_url='https://example.com', css_element='.mai
 - `css_element`: Mandatory. The CSS selector for a specific element to scrape from the website.
 - `cookie`: Optional. A dictionary containing cookie information. This parameter allows the tool to simulate a session with cookie information, providing access to content that may be restricted to logged-in users.
 - `wait_time`: Optional. The number of seconds the tool waits after loading the website and after setting a cookie, before scraping the content. This allows for dynamic content to load properly.
+- `return_html`: Optional. If True, the tool returns HTML content. If False, the tool returns text content.

--- a/tests/tools/selenium_scraping_tool_test.py
+++ b/tests/tools/selenium_scraping_tool_test.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock, patch
+
+from bs4 import BeautifulSoup
+
+from crewai_tools.tools.selenium_scraping_tool.selenium_scraping_tool import (
+    SeleniumScrapingTool,
+)
+
+
+def mock_driver_with_html(html_content):
+    driver = MagicMock()
+    mock_element = MagicMock()
+    mock_element.get_attribute.return_value = html_content
+    bs = BeautifulSoup(html_content, "html.parser")
+    mock_element.text = bs.get_text()
+
+    driver.find_elements.return_value = [mock_element]
+    driver.find_element.return_value = mock_element
+
+    return driver
+
+
+def initialize_tool_with(mock_driver):
+    tool = SeleniumScrapingTool()
+    tool.driver = MagicMock(return_value=mock_driver)
+
+    return tool
+
+
+def test_tool_initialization():
+    tool = SeleniumScrapingTool()
+
+    assert tool.website_url is None
+    assert tool.css_element is None
+    assert tool.cookie is None
+    assert tool.wait_time == 3
+    assert tool.return_html is False
+
+
+@patch("selenium.webdriver.Chrome")
+def test_scrape_without_css_selector(_mocked_chrome_driver):
+    html_content = "<html><body><div>test content</div></body></html>"
+    mock_driver = mock_driver_with_html(html_content)
+    tool = initialize_tool_with(mock_driver)
+
+    result = tool._run(website_url="https://example.com")
+
+    assert "test content" in result
+    mock_driver.get.assert_called_once_with("https://example.com")
+    mock_driver.find_element.assert_called_with("tag name", "body")
+    mock_driver.close.assert_called_once()
+
+
+@patch("selenium.webdriver.Chrome")
+def test_scrape_with_css_selector(_mocked_chrome_driver):
+    html_content = "<html><body><div>test content</div><div class='test'>test content in a specific div</div></body></html>"
+    mock_driver = mock_driver_with_html(html_content)
+    tool = initialize_tool_with(mock_driver)
+
+    result = tool._run(website_url="https://example.com", css_element="div.test")
+
+    assert "test content in a specific div" in result
+    mock_driver.get.assert_called_once_with("https://example.com")
+    mock_driver.find_elements.assert_called_with("css selector", "div.test")
+    mock_driver.close.assert_called_once()
+
+
+@patch("selenium.webdriver.Chrome")
+def test_scrape_with_return_html_true(_mocked_chrome_driver):
+    html_content = "<html><body><div>HTML content</div></body></html>"
+    mock_driver = mock_driver_with_html(html_content)
+    tool = initialize_tool_with(mock_driver)
+
+    result = tool._run(website_url="https://example.com", return_html=True)
+
+    assert html_content in result
+    mock_driver.get.assert_called_once_with("https://example.com")
+    mock_driver.find_element.assert_called_with("tag name", "body")
+    mock_driver.close.assert_called_once()
+
+
+@patch("selenium.webdriver.Chrome")
+def test_scrape_with_return_html_false(_mocked_chrome_driver):
+    html_content = "<html><body><div>HTML content</div></body></html>"
+    mock_driver = mock_driver_with_html(html_content)
+    tool = initialize_tool_with(mock_driver)
+
+    result = tool._run(website_url="https://example.com", return_html=False)
+
+    assert "HTML content" in result
+    mock_driver.get.assert_called_once_with("https://example.com")
+    mock_driver.find_element.assert_called_with("tag name", "body")
+    mock_driver.close.assert_called_once()


### PR DESCRIPTION
This pull request introduces a new feature to the `SeleniumScrapingTool` by adding a `return_html` flag. This is meant to provide users with the flexibility to choose between retrieving raw HTML content or plain text content from web pages during scraping operations.

## Advantages

- **Enhanced Flexibility**: Users can now choose the format of the scraped data, which is particularly useful for applications that require raw HTML for further processing or analysis.
- **Improved Usability**: The ability to toggle between HTML and text content makes the tool more versatile, catering to a broader range of use cases.
- **Backward Compatibility**: The default behaviour remains unchanged (returns text), ensuring that existing implementations are not affected unless the new flag is explicitly used.

## Use Cases

- **Data Extraction**: For applications that need to parse or manipulate HTML content directly, such as web page analysis or transformation tasks.
- **Content Verification**: Useful in scenarios where the structure of the HTML is as important as the content itself, such as in automated testing or web scraping for SEO analysis.

## Key Changes

1. **Add `return_html` Flag**:
   - **Type**: Boolean (optional).
   - **Default**: `False`.
   - **Functionality**: When set to `True`, the tool returns the HTML content of the specified elements or the entire page. When `False`, it returns the text content.

2. **Code Refactoring**:
   - Introduced helper methods `_get_content`, `_is_css_element_empty`, `_get_body_content`, and `_get_elements_content` to streamline the content retrieval process and improve code readability.

3. **Unit Tests**:
   - Added tests to verify the base functionality of the tool but also to verify the `return_html` flag, ensuring that both HTML and text content can be accurately retrieved based on the flag's value.
