### PR TITLE
Fix description on FileReadTool

### DIFF
--- a/crewai_tools/tools/file_read_tool/file_read_tool.py
+++ b/crewai_tools/tools/file_read_tool/file_read_tool.py
@@ -45,11 +45,11 @@ class FileReadTool(BaseTool):
                 this becomes the default file path for the tool.
             **kwargs: Additional keyword arguments passed to BaseTool.
         """
-        super().__init__(**kwargs)
         if file_path is not None:
-            self.file_path = file_path
-            self.description = f"A tool that reads file content. The default file is {file_path}, but you can provide a different 'file_path' parameter to read another file."
-            self._generate_description()
+            kwargs['description'] = f"A tool that reads file content. The default file is {file_path}, but you can provide a different 'file_path' parameter to read another file."
+        
+        super().__init__(**kwargs)
+        self.file_path = file_path
 
     def _run(
         self,

--- a/crewai_tools/tools/file_read_tool/file_read_tool.py
+++ b/crewai_tools/tools/file_read_tool/file_read_tool.py
@@ -49,6 +49,7 @@ class FileReadTool(BaseTool):
         if file_path is not None:
             self.file_path = file_path
             self.description = f"A tool that reads file content. The default file is {file_path}, but you can provide a different 'file_path' parameter to read another file."
+            self._generate_description()
 
     def _run(
         self,
@@ -68,14 +69,3 @@ class FileReadTool(BaseTool):
         except Exception as e:
             return f"Error: Failed to read file {file_path}. {str(e)}"
 
-    def _generate_description(self) -> None:
-        """Generate the tool description based on file path.
-
-        This method updates the tool's description to include information about
-        the default file path while maintaining the ability to specify a different
-        file at runtime.
-
-        Returns:
-            None
-        """
-        self.description = f"A tool that can be used to read {self.file_path}'s content."


### PR DESCRIPTION
The FileReadTool currently has a _description_generator method which overwrites the BaseTool method of the same name. 

The BaseTool _description_generator creates a richly formatted description like so: 
```
Tool Name: Search the internet
Tool Arguments: {
    'search_query': {
        'description': 'Mandatory search query you want to use to search the internet',
        'type': 'str'
    }
}
Tool Description: A tool that can be used to search the internet with a search_query. Supports different search types: 'search' (default), 'news'
```

Whereas the current _description_generator on the FileReadTool creates something like this: 
```
A tool that reads file content. The default file is my_file.txt, but you can provide a different 'file_path' parameter to read another file.
```

The BaseTool's version of this method is preferable and is used for other, more mature tools, such as the SerperDevTool and the ScrapeWebsiteTool, among others. 

When the FileReadTool is combined with, for example, the SerperDevTool and the ScrapeWebsiteTool, the resulting system prompt looks something like this: 
```
You are a Senior Example Agent

You're a seasoned Example Agent, with a deep understanding of agent design, specifically, agents that are made for examples.

Your personal goal is: this is an example goal.

You ONLY have access to the following tools, and should NEVER make up tools that are not listed here:

Tool Name: Search the internet
Tool Arguments: {
    'search_query': {
        'description': 'Mandatory search query you want to use to search the internet',
        'type': 'str'
    }
}
Tool Description: A tool that can be used to search the internet with a search_query. Supports different search types: 'search' (default), 'news'

Tool Name: Read website content
Tool Arguments: {
    'website_url': {
        'description': 'Mandatory website url to read the file',
        'type': 'str'
    }
}
Tool Description: A tool that can be used to read a website content.
A tool that reads file content. The default file is my_file.txt, but you can provide a different 'file_path' parameter to read another file.

Use the following format:

Thought: you should always think about what to do
Action: the action to take, only one name of [Search the internet, Read website content, Read a file's content], just the name, exactly as it's written.
Action Input: the input to the action, just a simple python dictionary, enclosed in curly braces, using " to wrap keys and values.
Observation: the result of the action

Once all necessary information is gathered:

Thought: I now know the final answer
Final Answer: the final answer to the original input question
```

This system prompt is most likely confusing for the LLM, as the FileReadTool description is of a different format and much less descriptive. 

Removing the _generate_description method on the FileReadTool will allow the description to be created by the method on the BaseTool, like is being done for SerperDevTool and ScrapeWebsiteTool, among others... and will result in a more consistent, machine-interpretable prompt file.

After the below changes, the system prompt looks like this: 
```
You are a Senior Example Agent

You're a seasoned Example Agent, with a deep understanding of agent design, specifically, agents that are made for examples.

Your personal goal is: this is an example goal.

You ONLY have access to the following tools, and should NEVER make up tools that are not listed here:

Tool Name: Search the internet
Tool Arguments: {
    'search_query': {
        'description': 'Mandatory search query you want to use to search the internet',
        'type': 'str'
    }
}
Tool Description: A tool that can be used to search the internet with a search_query. Supports different search types: 'search' (default), 'news'

Tool Name: Read website content
Tool Arguments: {
    'website_url': {
        'description': 'Mandatory website url to read the file',
        'type': 'str'
    }
}
Tool Description: A tool that can be used to read a website content.

Tool Name: Read a file's content
Tool Arguments: {
    'file_path': {
        'description': 'Mandatory file full path to read the file',
        'type': 'str'
    }
}
Tool Description: A tool that reads file content. The default file is my_file.txt, but you can provide a different 'file_path' parameter to read another file.

Use the following format:

Thought: you should always think about what to do
Action: the action to take, only one name of [Search the internet, Read website content, Read a file's content], just the name, exactly as it's written.
Action Input: the input to the action, just a simple python dictionary, enclosed in curly braces, using " to wrap keys and values.
Observation: the result of the action

Once all necessary information is gathered:

Thought: I now know the final answer
Final Answer: the final answer to the original input question
```

Note: add another call to _generate_description on line 52 because the description generated in super().__init__gets overwritten by line 51.