### PR TITLE
[Feature] Add Dappier Tools

### DIFF
--- a/crewai_tools/__init__.py
+++ b/crewai_tools/__init__.py
@@ -7,6 +7,8 @@ from .tools import (
     ComposioTool,
     CSVSearchTool,
     DallETool,
+    DappierAIRecommendationsTool,
+    DappierRealTimeSearchTool,
     DirectoryReadTool,
     DirectorySearchTool,
     DOCXSearchTool,

--- a/crewai_tools/tools/__init__.py
+++ b/crewai_tools/tools/__init__.py
@@ -6,6 +6,12 @@ from .code_interpreter_tool.code_interpreter_tool import CodeInterpreterTool
 from .composio_tool.composio_tool import ComposioTool
 from .csv_search_tool.csv_search_tool import CSVSearchTool
 from .dalle_tool.dalle_tool import DallETool
+from .dappier_ai_recommendations_tool.dappier_ai_recommendations_tool import (
+    DappierAIRecommendationsTool,
+)
+from .dappier_real_time_search_tool.dappier_real_time_search_tool import (
+    DappierRealTimeSearchTool,
+)
 from .directory_read_tool.directory_read_tool import DirectoryReadTool
 from .directory_search_tool.directory_search_tool import DirectorySearchTool
 from .docx_search_tool.docx_search_tool import DOCXSearchTool

--- a/crewai_tools/tools/dappier_ai_recommendations_tool/README.md
+++ b/crewai_tools/tools/dappier_ai_recommendations_tool/README.md
@@ -1,5 +1,7 @@
 # DappierAIRecommendationsTool
 
+The `DappierAIRecommendationsTool` fetches ai recommendations accross Sports and Lifestyle News to niche favorites like I Heart Dogs, I Heart Cats, WishTV and many more.
+
 ## Description
 
 [Dappier](https://dappier.com) connects any LLM or your Agentic AI to real-time, rights-cleared, proprietary data from trusted sources, making your AI an expert in anything. Our specialized models include Real-Time Web Search, News, Sports, Financial Stock Market Data, Crypto Data, and exclusive content from premium publishers. Explore a wide range of data models in our marketplace at [marketplace.dappier.com](https://marketplace.dappier.com).

--- a/crewai_tools/tools/dappier_ai_recommendations_tool/README.md
+++ b/crewai_tools/tools/dappier_ai_recommendations_tool/README.md
@@ -1,0 +1,67 @@
+# DappierAIRecommendationsTool
+
+## Description
+
+[Dappier](https://dappier.com) connects any LLM or your Agentic AI to real-time, rights-cleared, proprietary data from trusted sources, making your AI an expert in anything. Our specialized models include Real-Time Web Search, News, Sports, Financial Stock Market Data, Crypto Data, and exclusive content from premium publishers. Explore a wide range of data models in our marketplace at [marketplace.dappier.com](https://marketplace.dappier.com).
+
+## Key Features:
+
+- **AI-Powered Recommendations**:  
+  Search for recommendations in a wide variety of topics, including Sports, Lifestyle News, and niche topics like I Heart Dogs and WishTV, powered by advanced AI models.
+
+- **Customizable Data Model**:  
+  Use different data models to tailor recommendations to specific interests. The tool supports a wide range of pre-configured models, and the model ID can be customized for different types of recommendations.
+
+- **Flexible Search Algorithms**:  
+  Choose between several search algorithms, including:
+
+  - `most_recent`: Retrieve the latest articles.
+  - `semantic`: Retrieve articles based on semantic similarity to the query.
+  - `most_recent_semantic`: Combine both the most recent and semantic search methods.
+  - `trending`: Get trending articles based on user interest and activity.
+
+- **Top-K Document Retrieval**:  
+  Control the number of results returned by setting the `similarity_top_k` parameter, ensuring that the most relevant content is retrieved based on similarity.
+
+- **Reference Site Customization**:  
+  Optionally specify a reference domain (`ref`) where AI recommendations should be displayed. You can also control the number of articles returned from the reference site (`num_articles_ref`), while the remaining articles will come from other sources in the RAG model.
+
+- **Real-Time AI Recommendations**:  
+  Leverage real-time AI-powered recommendations to stay up-to-date with the latest articles, news, and trends across your preferred categories.
+
+For more information about Dappier, please visit the [Dappier website](https://dappier.com) or if you want to check out the docs, you can visit the [Dappier docs](https://docs.dappier.com).
+
+## Installation
+
+- Head to [Dappier](https://platform.dappier.com/profile/api-keys) to sign up and generate an API key. Once you've done this set the `DAPPIER_API_KEY` environment variable or you can pass it to the `DappierAIRecommendationsTool` constructor.
+- Install the `dappier` package.
+
+```bash
+pip install dappier 'crewai[tools]'
+```
+
+## Example
+
+Utilize the DappierAIRecommendationsTool as follows to allow your agent to access ai recommendations across Sports, Lifestyle News, and niche favorites like I Heart Dogs, I Heart Cats, WishTV, and many more.:
+
+```python
+from crewai_tools import DappierAIRecommendationsTool
+
+tool = DappierAIRecommendationsTool()
+```
+
+## Arguments
+
+`__init__` arguments:
+
+- `api_key`: Optional. Specifies the Dappier API key. If not provided, it will default to the `DAPPIER_API_KEY` environment variable.
+  - Can be passed directly during instantiation or set as an environment variable.
+
+`_run` arguments:
+
+- `query`: The user-provided input string for AI recommendations across various domains like Sports, Lifestyle News, and niche favorites.
+- `data_model_id`: Optional. Specifies the data model ID to use for recommendations. Defaults to `"dm_01j0pb465keqmatq9k83dthx34"`. Multiple data models are available at [Dappier Marketplace](https://marketplace.dappier.com/marketplace).
+- `similarity_top_k`: Optional. The number of top documents to retrieve based on similarity. Defaults to `9`.
+- `ref`: Optional. Specifies the site domain where AI recommendations should be displayed. Defaults to `None`.
+- `num_articles_ref`: Optional. Specifies the minimum number of articles to return from the specified reference domain (`ref`). Defaults to `0`.
+- `search_algorithm`: Optional. Specifies the search algorithm to use for retrieving articles. Defaults to `"most_recent"`. Options include `"most_recent"`, `"semantic"`, `"most_recent_semantic"`, and `"trending"`.

--- a/crewai_tools/tools/dappier_ai_recommendations_tool/dappier_ai_recommendations_tool.py
+++ b/crewai_tools/tools/dappier_ai_recommendations_tool/dappier_ai_recommendations_tool.py
@@ -107,5 +107,9 @@ class DappierAIRecommendationsTool(BaseTool):
 
             return results
 
+        except ConnectionError as e:
+            return {"error": f"Failed to connect to Dappier API: {e}"}
+        except ValueError as e:
+            return {"error": f"Invalid input parameters: {e}"}
         except Exception as e:
-            return {"error": f"An unexpected error occurred: {e!s}"}
+            return {"error": f"An unexpected error occurred: {str(e)}"}

--- a/crewai_tools/tools/dappier_ai_recommendations_tool/dappier_ai_recommendations_tool.py
+++ b/crewai_tools/tools/dappier_ai_recommendations_tool/dappier_ai_recommendations_tool.py
@@ -4,13 +4,15 @@ from typing import Any, Literal, Optional, Type
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+DEFAULT_DATA_MODEL_ID = "dm_01j0pb465keqmatq9k83dthx34"
+
 
 class DappierAIRecommendationsToolSchema(BaseModel):
     query: str = Field(
         description="The user-provided input string for AI recommendations across Sports, Lifestyle News, and niche favorites like I Heart Dogs, I Heart Cats, WishTV, and many more."
     )
     data_model_id: str = Field(
-        default="dm_01j0pb465keqmatq9k83dthx34",
+        default=DEFAULT_DATA_MODEL_ID,
         description="The data model ID to use for recommendations. Data model IDs always start with the prefix 'dm_'. Defaults to 'dm_01j0pb465keqmatq9k83dthx34'. Multiple AI models are available, which can be found at: https://marketplace.dappier.com/marketplace",
     )
     similarity_top_k: int = Field(
@@ -71,7 +73,7 @@ class DappierAIRecommendationsTool(BaseTool):
     def _run(
         self,
         query: str,
-        data_model_id: str = "dm_01j0pb465keqmatq9k83dthx34",
+        data_model_id: str = DEFAULT_DATA_MODEL_ID,
         similarity_top_k: int = 9,
         ref: Optional[str] = None,
         num_articles_ref: int = 0,

--- a/crewai_tools/tools/dappier_ai_recommendations_tool/dappier_ai_recommendations_tool.py
+++ b/crewai_tools/tools/dappier_ai_recommendations_tool/dappier_ai_recommendations_tool.py
@@ -54,7 +54,7 @@ class DappierAIRecommendationsTool(BaseTool):
 
     def __init__(self, api_key: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
-        self.api_key = api_key or os.environ["DAPPIER_API_KEY"]
+        self.api_key = self.get_api_key(api_key)
 
         try:
             from dappier import Dappier
@@ -69,6 +69,18 @@ class DappierAIRecommendationsTool(BaseTool):
             )
 
         self.dappier_client = Dappier(api_key=self.api_key)
+
+    @staticmethod
+    def get_api_key(api_key: Optional[str] = None) -> str:
+        if api_key:
+            return api_key
+
+        env_key = os.getenv("DAPPIER_API_KEY")
+        if not env_key:
+            raise ValueError(
+                "DAPPIER_API_KEY not found. Please provide via constructor or set DAPPIER_API_KEY environment variable."
+            )
+        return env_key
 
     def _run(
         self,

--- a/crewai_tools/tools/dappier_ai_recommendations_tool/dappier_ai_recommendations_tool.py
+++ b/crewai_tools/tools/dappier_ai_recommendations_tool/dappier_ai_recommendations_tool.py
@@ -1,0 +1,111 @@
+import os
+from typing import Any, Literal, Optional, Type
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class DappierAIRecommendationsToolSchema(BaseModel):
+    query: str = Field(
+        description="The user-provided input string for AI recommendations across Sports, Lifestyle News, and niche favorites like I Heart Dogs, I Heart Cats, WishTV, and many more."
+    )
+    data_model_id: str = Field(
+        default="dm_01j0pb465keqmatq9k83dthx34",
+        description="The data model ID to use for recommendations. Data model IDs always start with the prefix 'dm_'. Defaults to 'dm_01j0pb465keqmatq9k83dthx34'. Multiple AI models are available, which can be found at: https://marketplace.dappier.com/marketplace",
+    )
+    similarity_top_k: int = Field(
+        default=9,
+        description="The number of top documents to retrieve based on similarity. Defaults to 9.",
+    )
+    ref: Optional[str] = Field(
+        default=None,
+        description="The site domain where AI recommendations should be displayed. Defaults to None.",
+    )
+    num_articles_ref: int = Field(
+        default=0,
+        description="The minimum number of articles to return from the specified reference domain (`ref`). The remaining articles will come from other sites in the RAG model. Defaults to 0.",
+    )
+    search_algorithm: Literal[
+        "most_recent", "semantic", "most_recent_semantic", "trending"
+    ] = Field(
+        default="most_recent",
+        description="The search algorithm to use for retrieving articles. Defaults to 'most_recent'.",
+    )
+
+
+class DappierAIRecommendationsTool(BaseTool):
+    """DappierAIRecommendationsTool
+
+    Search ai recommendations accross Sports and Lifestyle News to niche favorites like I Heart Dogs, I Heart Cats, WishTV and many more.
+    Requires the `dappier` package.
+    Get your API Key from https://platform.dappier.com/profile/api-keys
+
+    Args:
+        api_key: The Dappier API key, can be set as an environment variable `DAPPIER_API_KEY` or passed directly
+    """
+
+    name: str = "Dappier ai recommendations tool"
+    description: str = "Search ai recommendations accross Sports and Lifestyle News to niche favorites like I Heart Dogs, I Heart Cats, WishTV and many more."
+    args_schema: Type[BaseModel] = DappierAIRecommendationsToolSchema
+    api_key: Optional[str] = None
+    dappier_client: Optional[Any] = None
+
+    def __init__(self, api_key: Optional[str] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.api_key = api_key or os.environ["DAPPIER_API_KEY"]
+
+        try:
+            from dappier import Dappier
+        except ImportError:
+            raise ImportError(
+                "`dappier` package not found, please run `pip install dappier`"
+            )
+
+        if not self.api_key:
+            raise ValueError(
+                "DAPPIER_API_KEY is not set. Please provide it either via the constructor with the `api_key` argument or by setting the DAPPIER_API_KEY environment variable."
+            )
+
+        self.dappier_client = Dappier(api_key=self.api_key)
+
+    def _run(
+        self,
+        query: str,
+        data_model_id: str = "dm_01j0pb465keqmatq9k83dthx34",
+        similarity_top_k: int = 9,
+        ref: Optional[str] = None,
+        num_articles_ref: int = 0,
+        search_algorithm: Literal[
+            "most_recent", "semantic", "most_recent_semantic", "trending"
+        ] = "most_recent",
+    ):
+        try:
+            response = self.dappier_client.get_ai_recommendations(  # type: ignore
+                query=query,
+                data_model_id=data_model_id,
+                similarity_top_k=similarity_top_k,
+                ref=ref,
+                num_articles_ref=num_articles_ref,
+                search_algorithm=search_algorithm,
+            )
+
+            if response is None or response.status != "success":
+                return {"error": "An unknown error occurred."}
+
+            # Collect only relevant information from the response.
+            results = [
+                {
+                    "author": result.author,
+                    "image_url": result.image_url,
+                    "pubdate": result.pubdate,
+                    "source_url": result.source_url,
+                    "summary": result.summary,
+                    "title": result.title,
+                }
+                for result in (getattr(response.response, "results", None) or [])
+            ]
+
+            return results
+
+        except Exception as e:
+            return {"error": f"An unexpected error occurred: {e!s}"}

--- a/crewai_tools/tools/dappier_real_time_search_tool/README.md
+++ b/crewai_tools/tools/dappier_real_time_search_tool/README.md
@@ -1,0 +1,55 @@
+# DappierRealTimeSearchTool
+
+## Description
+
+[Dappier](https://dappier.com) connects any LLM or your Agentic AI to real-time, rights-cleared, proprietary data from trusted sources, making your AI an expert in anything. Our specialized models include Real-Time Web Search, News, Sports, Financial Stock Market Data, Crypto Data, and exclusive content from premium publishers. Explore a wide range of data models in our marketplace at [marketplace.dappier.com](https://marketplace.dappier.com).
+
+## Key Features:
+
+- **Real-Time Web Search Results**:  
+  Fetch up-to-date search results from Google, including the latest news, weather updates, travel information, and deals.
+- **Stock Market and Financial Data**:  
+  Retrieve real-time financial news, stock prices, and trades powered by Polygon.io, along with AI-powered insights for better decision-making in the financial domain.
+- **Comprehensive Data Access**:  
+  Access a wide range of data from trusted, proprietary sources, including premium content from leading publishers across verticals like news, sports, finance, and weather.
+- **LLM-Ready Retrieval-Augmented Generation (RAG) Models**:  
+  Utilize pre-trained RAG models that ensure your AI-driven applications can return factual, relevant responses based on the most current data available.
+
+- **Flexible API Integration**:  
+  Integrate seamlessly with Dappier’s real-time data APIs to enhance your AI models and applications with up-to-date content from various sectors.
+
+- **Scalable Data Queries**:  
+  Tailor search queries to focus on specific data sources, enabling applications to respond to real-time demands in areas such as finance, sports, news, and weather.
+
+For more information about Dappier, please visit the [Dappier website](https://dappier.com) or if you want to check out the docs, you can visit the [Dappier docs](https://docs.dappier.com).
+
+## Installation
+
+- Head to [Dappier](https://platform.dappier.com/profile/api-keys) to sign up and generate an API key. Once you've done this set the `DAPPIER_API_KEY` environment variable or you can pass it to the `DappierRealTimeSearchTool` constructor.
+- Install the `dappier` package.
+
+```bash
+pip install dappier 'crewai[tools]'
+```
+
+## Example
+
+Utilize the DappierRealTimeSearchTool as follows to allow your agent to access real time data:
+
+```python
+from crewai_tools import DappierRealTimeSearchTool
+
+tool = DappierRealTimeSearchTool()
+```
+
+## Arguments
+
+`__init__` arguments:
+
+- `api_key`: Optional. Specifies the Dappier API key. If not provided, it will default to the `DAPPIER_API_KEY` environment variable.
+  - Can be passed directly during instantiation or set as an environment variable.
+
+`_run` arguments:
+
+- `query`: The user-provided input string for retrieving real-time data, including web search results, financial information, news, weather, and more, with AI-powered insights and updates.
+- `ai_model_id`: Optional. Specifies the AI model ID to use for the query. Defaults to `"am_01j06ytn18ejftedz6dyhz2b15"`. Multiple AI models are available at [Dappier Marketplace](https://marketplace.dappier.com/marketplace).

--- a/crewai_tools/tools/dappier_real_time_search_tool/README.md
+++ b/crewai_tools/tools/dappier_real_time_search_tool/README.md
@@ -1,5 +1,7 @@
 # DappierRealTimeSearchTool
 
+The `DappierRealTimeSearchTool` is desinged to search real time data, including web search results, financial information, news, weather, and more, with AI-powered insights and updates.
+
 ## Description
 
 [Dappier](https://dappier.com) connects any LLM or your Agentic AI to real-time, rights-cleared, proprietary data from trusted sources, making your AI an expert in anything. Our specialized models include Real-Time Web Search, News, Sports, Financial Stock Market Data, Crypto Data, and exclusive content from premium publishers. Explore a wide range of data models in our marketplace at [marketplace.dappier.com](https://marketplace.dappier.com).

--- a/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
+++ b/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
@@ -52,13 +52,11 @@ class DappierRealTimeSearchTool(BaseTool):
 
     def _run(self, query: str, ai_model_id: str = "am_01j06ytn18ejftedz6dyhz2b15"):
         try:
-            response = self.dappier_client.search_real_time_data(  # type: ignore
-                query=query, ai_model_id=ai_model_id
-            )
-
-            if response is None:
-                return "An unknown error occurred"
-
+            response = self.dappier_client.search_real_time_data(query=query, ai_model_id=ai_model_id)  # type: ignore
             return response.message
+        except ConnectionError as e:
+            return f"Failed to connect to Dappier API: {e}"
+        except ValueError as e:
+            return f"Invalid input parameters: {e}"
         except Exception as e:
-            return f"An unexpected error occurred: {e}"
+            return f"An unexpected error occurred: {str(e)}"

--- a/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
+++ b/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
@@ -1,0 +1,64 @@
+import os
+from typing import Any, Optional, Type
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class DappierRealTimeSearchToolSchema(BaseModel):
+    query: str = Field(
+        description="The user-provided input string for retrieving real-time data, including web search results, financial information, news, weather, and more, with AI-powered insights and updates."
+    )
+    ai_model_id: str = Field(
+        default="am_01j06ytn18ejftedz6dyhz2b15",
+        description="The AI model ID to use for the query. The AI model ID always starts with the prefix 'am_'. Defaults to 'am_01j06ytn18ejftedz6dyhz2b15'. Multiple AI models are available, which can be found at: https://marketplace.dappier.com/marketplace",
+    )
+
+
+class DappierRealTimeSearchTool(BaseTool):
+    """DappierRealTimeSearchTool
+
+    Search real time data, including web search results, financial information, news, weather, and more, with AI-powered insights and updates.
+    Requires the `dappier` package.
+    Get your API Key from https://platform.dappier.com/profile/api-keys
+
+    Args:
+        api_key: The Dappier API key, can be set as an environment variable `DAPPIER_API_KEY` or passed directly
+    """
+
+    name: str = "Dappier real time search tool"
+    description: str = "Search real time data, including web search results, financial information, news, weather, and more, with AI-powered insights and updates."
+    args_schema: Type[BaseModel] = DappierRealTimeSearchToolSchema
+    api_key: Optional[str] = None
+    dappier_client: Optional[Any] = None
+
+    def __init__(self, api_key: Optional[str] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.api_key = api_key or os.environ["DAPPIER_API_KEY"]
+
+        try:
+            from dappier import Dappier
+        except ImportError:
+            raise ImportError(
+                "`dappier` package not found, please run `pip install dappier`"
+            )
+
+        if not self.api_key:
+            raise ValueError(
+                "DAPPIER_API_KEY is not set. Please provide it either via the constructor with the `api_key` argument or by setting the DAPPIER_API_KEY environment variable."
+            )
+
+        self.dappier_client = Dappier(api_key=self.api_key)
+
+    def _run(self, query: str, ai_model_id: str = "am_01j06ytn18ejftedz6dyhz2b15"):
+        try:
+            response = self.dappier_client.search_real_time_data(  # type: ignore
+                query=query, ai_model_id=ai_model_id
+            )
+
+            if response is None:
+                return "An unknown error occurred"
+
+            return response.message
+        except Exception as e:
+            return f"An unexpected error occurred: {e}"

--- a/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
+++ b/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
@@ -4,13 +4,15 @@ from typing import Any, Optional, Type
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+DEFAULT_AI_MODEL_ID = "am_01j06ytn18ejftedz6dyhz2b15"
+
 
 class DappierRealTimeSearchToolSchema(BaseModel):
     query: str = Field(
         description="The user-provided input string for retrieving real-time data, including web search results, financial information, news, weather, and more, with AI-powered insights and updates."
     )
     ai_model_id: str = Field(
-        default="am_01j06ytn18ejftedz6dyhz2b15",
+        default=DEFAULT_AI_MODEL_ID,
         description="The AI model ID to use for the query. The AI model ID always starts with the prefix 'am_'. Defaults to 'am_01j06ytn18ejftedz6dyhz2b15'. Multiple AI models are available, which can be found at: https://marketplace.dappier.com/marketplace",
     )
 
@@ -50,7 +52,7 @@ class DappierRealTimeSearchTool(BaseTool):
 
         self.dappier_client = Dappier(api_key=self.api_key)
 
-    def _run(self, query: str, ai_model_id: str = "am_01j06ytn18ejftedz6dyhz2b15"):
+    def _run(self, query: str, ai_model_id: str = DEFAULT_AI_MODEL_ID):
         try:
             response = self.dappier_client.search_real_time_data(query=query, ai_model_id=ai_model_id)  # type: ignore
             return response.message

--- a/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
+++ b/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
@@ -36,7 +36,7 @@ class DappierRealTimeSearchTool(BaseTool):
 
     def __init__(self, api_key: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
-        self.api_key = api_key or os.environ["DAPPIER_API_KEY"]
+        self.api_key = self.get_api_key(api_key)
 
         try:
             from dappier import Dappier
@@ -51,6 +51,18 @@ class DappierRealTimeSearchTool(BaseTool):
             )
 
         self.dappier_client = Dappier(api_key=self.api_key)
+
+    @staticmethod
+    def get_api_key(api_key: Optional[str] = None) -> str:
+        if api_key:
+            return api_key
+
+        env_key = os.getenv("DAPPIER_API_KEY")
+        if not env_key:
+            raise ValueError(
+                "DAPPIER_API_KEY not found. Please provide via constructor or set DAPPIER_API_KEY environment variable."
+            )
+        return env_key
 
     def _run(self, query: str, ai_model_id: str = DEFAULT_AI_MODEL_ID):
         try:

--- a/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
+++ b/crewai_tools/tools/dappier_real_time_search_tool/dappier_real_time_search_tool.py
@@ -55,6 +55,10 @@ class DappierRealTimeSearchTool(BaseTool):
     def _run(self, query: str, ai_model_id: str = DEFAULT_AI_MODEL_ID):
         try:
             response = self.dappier_client.search_real_time_data(query=query, ai_model_id=ai_model_id)  # type: ignore
+
+            if response is None:
+                return "An unknown error occurred"
+
             return response.message
         except ConnectionError as e:
             return f"Failed to connect to Dappier API: {e}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,9 @@ scrapegraph-py = [
 linkup-sdk = [
     "linkup-sdk>=0.2.2",
 ]
-
+dappier = [
+    "dappier>=0.3.3"
+]
 hyperbrowser = [
     "hyperbrowser>=0.18.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -194,6 +194,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncio"
+version = "3.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/54/054bafaf2c0fb8473d423743e191fcdf49b2c1fd5e9af3524efbe097bafd/asyncio-3.4.3.tar.gz", hash = "sha256:83360ff8bc97980e4ff25c964c7bd3923d333d177aa4f7fb736b019f26c7cb41", size = 204411 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/74/07679c5b9f98a7cb0fc147b1ef1cc1853bc07a4eb9cb5731e24732c5f773/asyncio-3.4.3-py3-none-any.whl", hash = "sha256:c4d18b22701821de07bd6aea8b53d21449ec0ec5680645e5317062ea21817d2d", size = 101767 },
+]
+
+[[package]]
 name = "attrs"
 version = "24.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -530,7 +539,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -666,6 +675,9 @@ browserbase = [
 composio-core = [
     { name = "composio-core" },
 ]
+dappier = [
+    { name = "dappier" },
+]
 firecrawl-py = [
     { name = "firecrawl-py" },
 ]
@@ -708,6 +720,12 @@ weaviate-client = [
     { name = "weaviate-client" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'beautifulsoup4'", specifier = ">=4.12.3" },
@@ -717,6 +735,7 @@ requires-dist = [
     { name = "composio-core", marker = "extra == 'composio-core'", specifier = ">=0.6.11.post1" },
     { name = "crewai", specifier = ">=0.95.0" },
     { name = "cryptography", marker = "extra == 'snowflake'", specifier = ">=43.0.3" },
+    { name = "dappier", marker = "extra == 'dappier'", specifier = ">=0.3.3" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "embedchain", specifier = ">=0.1.114" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl-py'", specifier = ">=1.8.0" },
@@ -739,6 +758,12 @@ requires-dist = [
     { name = "spider-client", marker = "extra == 'spider-client'", specifier = ">=0.1.25" },
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0.35" },
     { name = "weaviate-client", marker = "extra == 'weaviate-client'", specifier = ">=4.10.2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25.2" },
 ]
 
 [[package]]
@@ -772,6 +797,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/93/90/116edd5f8ec23b2dc879f7a42443e073cdad22950d3c8ee834e3b8124543/cryptography-43.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a2a431ee15799d6db9fe80c82b055bae5a752bef645bba795e8e52687c69efe3", size = 3679828 },
     { url = "https://files.pythonhosted.org/packages/d8/32/1e1d78b316aa22c0ba6493cc271c1c309969e5aa5c22c830a1d7ce3471e6/cryptography-43.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:281c945d0e28c92ca5e5930664c1cefd85efe80e5c0d2bc58dd63383fda29f83", size = 3908132 },
     { url = "https://files.pythonhosted.org/packages/91/bb/cd2c13be3332e7af3cdf16154147952d39075b9f61ea5e6b5241bf4bf436/cryptography-43.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f18c716be16bc1fea8e95def49edf46b82fccaa88587a45f8dc0ff6ab5d8e0a7", size = 2988811 },
+]
+
+[[package]]
+name = "dappier"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asyncio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/db/6e35d0b67cc94a7064a71bb70df7fbc89cd99980e529600b0476292aa205/dappier-0.3.3.tar.gz", hash = "sha256:0e0e1e9ce91f550e20d9e2d86a6121c1497f1004ab72bc85222f49bb3ac5d6e0", size = 5935 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/9d/78f383a280f721d7abb49886c3a644f61bf6527e74fafebb719e68f8fa21/dappier-0.3.3-py3-none-any.whl", hash = "sha256:05390cca61235d592aacc35b521cc5eb927a9954b786b390d1d7609a6ef79f20", size = 8498 },
 ]
 
 [[package]]
@@ -1700,6 +1739,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/7e/691d061b7329bc8d54edbf0ec22fbfb2afe61facb681f9aaa9bff7a27d04/inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417", size = 15091 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2", size = 9454 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
 ]
 
 [[package]]
@@ -3035,11 +3083,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
 name = "portalocker"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "platform_system == 'Windows'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f", size = 40891 }
 wheels = [
@@ -3532,6 +3589,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/df/adcc0d60f1053d74717d21d58c0048479e9cab51464ce0d2965b086bd0e2/pytest_asyncio-0.25.2.tar.gz", hash = "sha256:3f8ef9a98f45948ea91a0ed3dc4268b5326c0e7bce73892acc654df4262ad45f", size = 53950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/d8/defa05ae50dcd6019a95527200d3b3980043df5aa445d40cb0ef9f7f98ab/pytest_asyncio-0.25.2-py3-none-any.whl", hash = "sha256:0d0bb693f7b99da304a0634afc0a4b19e49d5e0de2d670f38dc4bfa5727c5075", size = 19400 },
 ]
 
 [[package]]
@@ -4439,7 +4525,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
# Dappier

[Dappier](https://dappier.com) connects any LLM or your Agentic AI to real-time, rights-cleared, proprietary data from trusted sources, making your AI an expert in anything. Our specialized models include Real-Time Web Search, News, Sports, Financial Stock Market Data, Crypto Data, and exclusive content from premium publishers. Explore a wide range of data models in our marketplace at [marketplace.dappier.com](https://marketplace.dappier.com).

## DappierRealTimeSearchTool

The `DappierRealTimeSearchTool` is desinged to search real time data, including web search results, financial information, news, weather, and more, with AI-powered insights and updates.

### Usage

```python
from crewai_tools import DappierRealTimeSearchTool

tool = DappierRealTimeSearchTool()

response = tool.run(query="crew ai latest news")
```

```
Using Tool: Dappier real time search tool
Here’s the latest on Crew AI:

- **Integration with NVIDIA**: Crew AI has teamed up with NVIDIA to enhance their production-grade AI agents, making workflows even smoother! This was announced on January 7, 2025.

- **Collaboration with Cloudera**: They’re also working with Cloudera to bring precision to enterprise workflows using AI agents.

- **New Features**: They just launched version 0.70.1, which includes a cool feature called `crewai chat` that allows real conversations with AI crews! 

- **Funding Success**: Crew AI recently secured $18 million in Series A funding to boost their growth, and they now have over 10 million agents automating complex workflows across various platforms.

- **No-Code Assistant**: They’re promoting a no-code assistant that helps users build and deploy automated workflows easily.

Looks like Crew AI is on a roll! 🚀✨
```

## DappierAIRecommendationsTool

The `DappierAIRecommendationsTool` fetches ai recommendations accross Sports and Lifestyle News to niche favorites like I Heart Dogs, I Heart Cats, WishTV and many more.

### Usage

```python
from crewai_tools import DappierAIRecommendationsTool

tool = DappierAIRecommendationsTool()

response = tool.run(
    query="latest sports news",
    data_model_id="dm_01j0pb465keqmatq9k83dthx34",
    similarity_top_k=3,
    ref="sportsnaut.com",
    num_articles_ref=2,
    search_algorithm="most_recent",
)
```

```
[{'author': 'Matt Weaver',
  'image_url': 'https://images.dappier.com/dm_01j0pb465keqmatq9k83dthx34/Screenshot_20250117_021643_Gallery_.jpg?width=428&height=321',
  'pubdate': 'Fri, 17 Jan 2025 08:04:03 +0000',
  'source_url': 'https://sportsnaut.com/chili-bowl-thursday-bell-column/',
  'summary': "The article highlights the thrilling unpredictability of the Chili Bowl Midget Nationals, focusing on the dramatic shifts in fortune for drivers like Christopher Bell, Tanner Thorson, and Karter Sarff during Thursday's events. Key moments included Sarff's unfortunate pull-off and a last-lap crash that allowed Ryan Bernal to capitalize and improve his standing, showcasing the chaotic nature of the race and the importance of strategy and luck.\n\nAs the competition intensifies leading up to Championship Saturday, Bell faces the challenge of racing from a Last Chance Race, reflecting on the excitement and difficulties of the sport. The article emphasizes the emotional highs and lows experienced by racers, with insights from Bell and Bernal on the unpredictable nature of racing. Overall, it captures the camaraderie and passion that define the Chili Bowl, illustrating how each moment contributes to the event's narrative.",
  'title': 'Thursday proves why every lap of Chili Bowl is so consequential'},
 {'author': 'Matt Higgins',
  'image_url': 'https://images.dappier.com/dm_01j0pb465keqmatq9k83dthx34/Pete-Alonso-24524027_.jpg?width=428&height=321',
  'pubdate': 'Fri, 17 Jan 2025 02:48:42 +0000',
  'source_url': 'https://sportsnaut.com/new-york-mets-news-pete-alonso-rejected-last-ditch-contract-offer/',
  'summary': "The New York Mets are likely parting ways with star first baseman Pete Alonso after failing to finalize a contract agreement. Alonso rejected a last-minute three-year offer worth between $68 and $70 million, leading the Mets to redirect funds towards acquiring a top reliever. With Alonso's free-agent options dwindling, speculation arises about his potential signing with another team for the 2025 season, while the Mets plan to shift Mark Vientos to first base.\n\nIn a strategic move, the Mets are also considering a trade for Toronto Blue Jays' star first baseman Vladimir Guerrero Jr. This potential acquisition aims to enhance the Mets' competitiveness as they reshape their roster. Guerrero's impressive offensive stats make him a valuable target, and discussions are in the early stages. Fans and analysts are keenly watching the situation, as a trade involving such a prominent player could significantly impact both teams.",
  'title': 'MLB insiders reveal New York Mets’ last-ditch contract offer that Pete Alonso rejected'},
 {'author': 'Jim Cerny',
  'image_url': 'https://images.dappier.com/dm_01j0pb465keqmatq9k83dthx34/NHL-New-York-Rangers-at-Utah-25204492_.jpg?width=428&height=321',
  'pubdate': 'Fri, 17 Jan 2025 05:10:39 +0000',
  'source_url': 'https://www.foreverblueshirts.com/new-york-rangers-news/stirring-5-3-comeback-win-utah-close-road-trip/',
  'summary': "The New York Rangers achieved a thrilling 5-3 comeback victory against the Utah Hockey Club, showcasing their resilience after a prior overtime loss. The Rangers scored three unanswered goals in the third period, with key contributions from Reilly Smith, Chris Kreider, and Artemi Panarin, who sealed the win with an empty-net goal. This victory marked their first win of the season when trailing after two periods and capped off a successful road trip, improving their record to 21-20-3.\n\nIgor Shesterkin's strong performance in goal, along with Arthur Kaliyev's first goal for the team, helped the Rangers overcome an early deficit. The game featured multiple lead changes, highlighting the competitive nature of both teams. As the Rangers prepare for their next game against the Columbus Blue Jackets, they aim to close the gap in the playoff race, with the Blue Jackets currently holding a five-point lead in the Eastern Conference standings.",
  'title': 'Rangers score 3 times in 3rd period for stirring 5-3 comeback win against Utah to close road trip'}]
```