### PR TITLE
fix[rag]: Add loader kwargs to allow rag tools class to instantiate properly

### DIFF
--- a/crewai_tools/tools/directory_search_tool/directory_search_tool.py
+++ b/crewai_tools/tools/directory_search_tool/directory_search_tool.py
@@ -32,7 +32,7 @@ class DirectorySearchTool(RagTool):
         super().__init__(**kwargs)
         if directory is not None:
             kwargs["loader"] = DirectoryLoader(config=dict(recursive=True))
-            self.add(directory)
+            self.add(directory, loader=kwargs["loader"])
             self.description = f"A tool that can be used to semantic search a query the {directory} directory's content."
             self.args_schema = FixedDirectorySearchToolSchema
             self._generate_description()

--- a/crewai_tools/tools/github_search_tool/github_search_tool.py
+++ b/crewai_tools/tools/github_search_tool/github_search_tool.py
@@ -39,7 +39,7 @@ class GithubSearchTool(RagTool):
             kwargs["data_type"] = "github"
             kwargs["loader"] = GithubLoader(config={"token": self.gh_token})
 
-            self.add(repo=github_repo)
+            self.add(repo=github_repo, loader=kwargs["loader"], data_type=kwargs["data_type"])
             self.description = f"A tool that can be used to semantic search a query the {github_repo} github repo's content. This is not the GitHub API, but instead a tool that can provide semantic search capabilities."
             self.args_schema = FixedGithubSearchToolSchema
             self._generate_description()

--- a/crewai_tools/tools/pg_seach_tool/pg_search_tool.py
+++ b/crewai_tools/tools/pg_seach_tool/pg_search_tool.py
@@ -25,7 +25,7 @@ class PGSearchTool(RagTool):
         super().__init__(**kwargs)
         kwargs["data_type"] = "postgres"
         kwargs["loader"] = PostgresLoader(config=dict(url=self.db_uri))
-        self.add(table_name)
+        self.add(table_name, loader=kwargs["loader"], data_type=kwargs["data_type"])
         self.description = f"A tool that can be used to semantic search a query the {table_name} database table's content."
         self._generate_description()
 


### PR DESCRIPTION
fixes : #205

With the fix, it's populating:
<img width="1143" alt="Screenshot 2025-02-10 at 4 02 33 PM" src="https://github.com/user-attachments/assets/a9425060-e222-4fbd-972a-08e670b5e029" />
