### PR TITLE
Elasticsearch tool - but not for RAG purposes

### DIFF
--- a/crewai_tools/__init__.py
+++ b/crewai_tools/__init__.py
@@ -10,6 +10,8 @@ from .tools import (
     DirectoryReadTool,
     DirectorySearchTool,
     DOCXSearchTool,
+    ElasticsearchConfig,
+    ElasticsearchSearchTool,
     EXASearchTool,
     FileReadTool,
     FileWriterTool,

--- a/crewai_tools/tools/__init__.py
+++ b/crewai_tools/tools/__init__.py
@@ -9,6 +9,11 @@ from .dalle_tool.dalle_tool import DallETool
 from .directory_read_tool.directory_read_tool import DirectoryReadTool
 from .directory_search_tool.directory_search_tool import DirectorySearchTool
 from .docx_search_tool.docx_search_tool import DOCXSearchTool
+from .elasticsearch_tool import (
+    ElasticsearchConfig,
+    ElasticsearchSearchTool,
+    ElasticsearchSearchToolInput,
+)
 from .exa_tools.exa_search_tool import EXASearchTool
 from .file_read_tool.file_read_tool import FileReadTool
 from .file_writer_tool.file_writer_tool import FileWriterTool

--- a/crewai_tools/tools/elasticsearch_tool/README.md
+++ b/crewai_tools/tools/elasticsearch_tool/README.md
@@ -1,5 +1,3 @@
-from pydantic import SecretStr
-
 # Elasticsearch Tool
 
 A tool for executing queries on Elastic database with built-in connection pooling, retry logic, and async execution support.

--- a/crewai_tools/tools/elasticsearch_tool/README.md
+++ b/crewai_tools/tools/elasticsearch_tool/README.md
@@ -97,10 +97,10 @@ A powerful tool for executing searches on Elasticsearch with support for both se
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| pool_size | 5 | Size of connection pool |
-| max_retries | 3 | Maximum retry attempts for failed searches |
-| retry_delay | 1.0 | Delay between retries in seconds |
-| enable_caching | True | Enable/disable search result caching |
+| pool_size | 5       | Size of connection pool |
+| max_retries | 3       | Maximum retry attempts for failed searches |
+| retry_delay | 1.0     | Delay between retries in seconds |
+| enable_caching | False   | Enable/disable search result caching |
 
 ## Advanced Usage
 

--- a/crewai_tools/tools/elasticsearch_tool/README.md
+++ b/crewai_tools/tools/elasticsearch_tool/README.md
@@ -1,0 +1,155 @@
+# Elasticsearch Tool
+
+A tool for executing queries on Elastic database with built-in connection pooling, retry logic, and async execution support.
+
+## Installation
+
+```bash
+uv sync --extra snowflake
+
+OR 
+uv pip install snowflake-connector-python>=3.5.0 snowflake-sqlalchemy>=1.5.0 cryptography>=41.0.0
+
+OR 
+pip install snowflake-connector-python>=3.5.0 snowflake-sqlalchemy>=1.5.0 cryptography>=41.0.0
+```
+
+## Quick Start
+
+```python
+import asyncio
+from crewai_tools import SnowflakeSearchTool, SnowflakeConfig
+
+# Create configuration
+config = SnowflakeConfig(
+    account="your_account",
+    user="your_username", 
+    password="your_password",
+    warehouse="COMPUTE_WH",
+    database="your_database",
+    snowflake_schema="your_schema"  # Note: Uses snowflake_schema instead of schema
+)
+
+# Initialize tool
+tool = SnowflakeSearchTool(
+    config=config,
+    pool_size=5,
+    max_retries=3,
+    enable_caching=True
+)
+
+# Execute query
+async def main():
+    results = await tool._run(
+        query="SELECT * FROM your_table LIMIT 10",
+        timeout=300
+    )
+    print(f"Retrieved {len(results)} rows")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## Features
+
+- ✨ Asynchronous query execution
+- 🚀 Connection pooling for better performance
+- 🔄 Automatic retries for transient failures
+- 💾 Query result caching (optional)
+- 🔒 Support for both password and key-pair authentication
+- 📝 Comprehensive error handling and logging
+
+## Configuration Options
+
+### SnowflakeConfig Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| account | Yes | Snowflake account identifier |
+| user | Yes | Snowflake username |
+| password | Yes* | Snowflake password |
+| private_key_path | No* | Path to private key file (alternative to password) |
+| warehouse | Yes | Snowflake warehouse name |
+| database | Yes | Default database |
+| snowflake_schema | Yes | Default schema |
+| role | No | Snowflake role |
+| session_parameters | No | Custom session parameters dict |
+
+\* Either password or private_key_path must be provided
+
+### Tool Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| pool_size | 5 | Number of connections in the pool |
+| max_retries | 3 | Maximum retry attempts for failed queries |
+| retry_delay | 1.0 | Delay between retries in seconds |
+| enable_caching | True | Enable/disable query result caching |
+
+## Advanced Usage
+
+### Using Key-Pair Authentication
+
+```python
+config = SnowflakeConfig(
+    account="your_account",
+    user="your_username",
+    private_key_path="/path/to/private_key.p8",
+    warehouse="your_warehouse",
+    database="your_database",
+    snowflake_schema="your_schema"
+)
+```
+
+### Custom Session Parameters
+
+```python
+config = SnowflakeConfig(
+    # ... other config parameters ...
+    session_parameters={
+        "QUERY_TAG": "my_app",
+        "TIMEZONE": "America/Los_Angeles"
+    }
+)
+```
+
+## Best Practices
+
+1. **Error Handling**: Always wrap query execution in try-except blocks
+2. **Logging**: Enable logging to track query execution and errors
+3. **Connection Management**: Use appropriate pool sizes for your workload
+4. **Timeouts**: Set reasonable query timeouts to prevent hanging
+5. **Security**: Use key-pair auth in production and never hardcode credentials
+
+## Example with Logging
+
+```python
+import logging
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+async def main():
+    try:
+        # ... tool initialization ...
+        results = await tool._run(query="SELECT * FROM table LIMIT 10")
+        logger.info(f"Query completed successfully. Retrieved {len(results)} rows")
+    except Exception as e:
+        logger.error(f"Query failed: {str(e)}")
+        raise
+```
+
+## Error Handling
+
+The tool automatically handles common Snowflake errors:
+- DatabaseError
+- OperationalError
+- ProgrammingError
+- Network timeouts
+- Connection issues
+
+Errors are logged and retried based on your retry configuration. 

--- a/crewai_tools/tools/elasticsearch_tool/__init__.py
+++ b/crewai_tools/tools/elasticsearch_tool/__init__.py
@@ -1,0 +1,11 @@
+from .elasticsearch_tool import (
+    ElasticsearchConfig,
+    ElasticsearchSearchTool,
+    ElasticsearchSearchToolInput,
+)
+
+__all__ = [
+    "ElasticsearchConfig",
+    "ElasticsearchSearchTool",
+    "ElasticsearchSearchToolInput",
+]

--- a/crewai_tools/tools/elasticsearch_tool/elasticsearch_tool.py
+++ b/crewai_tools/tools/elasticsearch_tool/elasticsearch_tool.py
@@ -78,7 +78,7 @@ class ElasticsearchSearchTool(BaseTool):
         default=1.0, description="Delay between retries in seconds"
     )
     enable_caching: bool = Field(
-        default=True, description="Enable search result caching"
+        default=False, description="Enable search result caching"
     )
 
     model_config = ConfigDict(

--- a/crewai_tools/tools/elasticsearch_tool/elasticsearch_tool.py
+++ b/crewai_tools/tools/elasticsearch_tool/elasticsearch_tool.py
@@ -60,8 +60,6 @@ class ElasticsearchSearchToolInput(BaseModel):
 
 
 class ElasticsearchSearchTool(BaseTool):
-    """Tool for executing searches on Elasticsearch."""
-
     name: str = "Elasticsearch Search"
     description: str = (
         "Execute searches on Elasticsearch using Query DSL or simple query string syntax. "
@@ -126,7 +124,6 @@ class ElasticsearchSearchTool(BaseTool):
                 )
 
     def _create_client(self) -> None:
-        """Create Elasticsearch client with configured settings."""
         client_params = {
             "verify_certs": self.config.verify_certs,
         }
@@ -147,7 +144,6 @@ class ElasticsearchSearchTool(BaseTool):
         self._client = AsyncElasticsearch(**client_params)
 
     def _get_cache_key(self, query: str, index: str, size: int, timeout: str) -> str:
-        """Generate a cache key for the search."""
         return f"{index}:{query}:{size}:{timeout}"
 
     async def _execute_search(
@@ -158,8 +154,6 @@ class ElasticsearchSearchTool(BaseTool):
         timeout: str = "30s",
         routing: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Execute a search with retries and return results."""
-
         search_index = index or self.config.default_index
         if not search_index:
             raise ValueError("No index specified and no default index configured")
@@ -214,8 +208,6 @@ class ElasticsearchSearchTool(BaseTool):
         routing: Optional[str] = None,
         **kwargs: Any,
     ) -> Any:
-        """Execute the search query."""
-
         try:
             results = await self._execute_search(
                 query=query, index=index, size=size, timeout=timeout, routing=routing
@@ -226,18 +218,15 @@ class ElasticsearchSearchTool(BaseTool):
             raise
 
     async def __aenter__(self):
-        """Async context manager entry."""
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Async context manager exit."""
         if self._client:
             await self._client.close()
         if self._thread_pool:
             self._thread_pool.shutdown()
 
     def __del__(self):
-        """Cleanup resources on deletion."""
         try:
             if self._client:
                 asyncio.run(self._client.close())

--- a/crewai_tools/tools/elasticsearch_tool/elasticsearch_tool.py
+++ b/crewai_tools/tools/elasticsearch_tool/elasticsearch_tool.py
@@ -1,0 +1,256 @@
+import asyncio
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List, Optional, Type
+
+from crewai.tools.base_tool import BaseTool
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
+
+try:
+    from elasticsearch import AsyncElasticsearch
+    from elasticsearch.exceptions import ConnectionError, RequestError
+
+    ELASTICSEARCH_AVAILABLE = True
+except ImportError:
+    ELASTICSEARCH_AVAILABLE = False
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Cache for search results
+_search_cache = {}
+
+
+class ElasticsearchConfig(BaseModel):
+    """Configuration for Elasticsearch connection."""
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    hosts: List[str] = Field(..., description="List of Elasticsearch hosts")
+    username: Optional[str] = Field(None, description="Elasticsearch username")
+    password: Optional[SecretStr] = Field(None, description="Elasticsearch password")
+    api_key: Optional[SecretStr] = Field(None, description="Elasticsearch API key")
+    cloud_id: Optional[str] = Field(None, description="Elasticsearch Cloud ID")
+    verify_certs: bool = Field(True, description="Verify SSL certificates")
+    default_index: Optional[str] = Field(None, description="Default index to search")
+
+    @property
+    def has_auth(self) -> bool:
+        return bool((self.username and self.password) or self.api_key or self.cloud_id)
+
+    def model_post_init(self, *args, **kwargs):
+        if not self.hosts and not self.cloud_id:
+            raise ValueError("Either hosts or cloud_id must be provided")
+
+
+class ElasticsearchSearchToolInput(BaseModel):
+    """Input schema for ElasticsearchSearchTool."""
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    query: str = Field(
+        ..., description="Elasticsearch query (JSON string or query string)"
+    )
+    index: Optional[str] = Field(None, description="Override default index")
+    size: Optional[int] = Field(10, description="Maximum number of results")
+    timeout: Optional[str] = Field("30s", description="Search timeout")
+    routing: Optional[str] = Field(None, description="Routing value")
+
+
+class ElasticsearchSearchTool(BaseTool):
+    """Tool for executing searches on Elasticsearch."""
+
+    name: str = "Elasticsearch Search"
+    description: str = (
+        "Execute searches on Elasticsearch using Query DSL or simple query string syntax. "
+        "Supports both structured queries and natural language search."
+    )
+    args_schema: Type[BaseModel] = ElasticsearchSearchToolInput
+
+    config: ElasticsearchConfig = Field(
+        ..., description="Elasticsearch connection configuration"
+    )
+    pool_size: int = Field(default=5, description="Size of connection pool")
+    max_retries: int = Field(default=3, description="Maximum retry attempts")
+    retry_delay: float = Field(
+        default=1.0, description="Delay between retries in seconds"
+    )
+    enable_caching: bool = Field(
+        default=True, description="Enable search result caching"
+    )
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, validate_assignment=True, frozen=False
+    )
+
+    _client: Optional[AsyncElasticsearch] = None
+    _thread_pool: Optional[ThreadPoolExecutor] = None
+    _model_rebuilt: bool = False
+
+    def __init__(self, **data):
+        """Initialize ElasticsearchSearchTool."""
+        super().__init__(**data)
+        self._initialize_elasticsearch()
+
+    def _initialize_elasticsearch(self) -> None:
+        """Initialize Elasticsearch client and resources."""
+        try:
+            if ELASTICSEARCH_AVAILABLE:
+                self._thread_pool = ThreadPoolExecutor(max_workers=self.pool_size)
+                self._create_client()
+            else:
+                raise ImportError
+        except ImportError:
+            import click
+
+            if click.confirm(
+                "You are missing the 'elasticsearch' package. Would you like to install it?"
+            ):
+                import subprocess
+
+                try:
+                    subprocess.run(
+                        ["uv", "add", "elasticsearch"],
+                        check=True,
+                    )
+                    self._thread_pool = ThreadPoolExecutor(max_workers=self.pool_size)
+                    self._create_client()
+                except subprocess.CalledProcessError:
+                    raise ImportError("Failed to install Elasticsearch dependencies")
+            else:
+                raise ImportError(
+                    "Elasticsearch dependencies not found. Please install them by running "
+                    "`uv add elasticsearch`"
+                )
+
+    def _create_client(self) -> None:
+        """Create Elasticsearch client with configured settings."""
+        client_params = {
+            "verify_certs": self.config.verify_certs,
+        }
+
+        if self.config.cloud_id:
+            client_params["cloud_id"] = self.config.cloud_id
+        else:
+            client_params["hosts"] = self.config.hosts
+
+        if self.config.username and self.config.password:
+            client_params["basic_auth"] = (
+                self.config.username,
+                self.config.password.get_secret_value(),
+            )
+        elif self.config.api_key:
+            client_params["api_key"] = self.config.api_key.get_secret_value()
+
+        self._client = AsyncElasticsearch(**client_params)
+
+    def _get_cache_key(self, query: str, index: str, size: int, timeout: str) -> str:
+        """Generate a cache key for the search."""
+        return f"{index}:{query}:{size}:{timeout}"
+
+    async def _execute_search(
+        self,
+        query: str,
+        index: Optional[str] = None,
+        size: int = 10,
+        timeout: str = "30s",
+        routing: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Execute a search with retries and return results."""
+
+        search_index = index or self.config.default_index
+        if not search_index:
+            raise ValueError("No index specified and no default index configured")
+
+        if self.enable_caching:
+            cache_key = self._get_cache_key(query, search_index, size, timeout)
+            if cache_key in _search_cache:
+                logger.info("Returning cached result")
+                return _search_cache[cache_key]
+
+        for attempt in range(self.max_retries):
+            try:
+                # Try to parse as JSON query first
+                try:
+                    search_body = json.loads(query)
+                except json.JSONDecodeError:
+                    # Fall back to query string
+                    search_body = {"query": {"query_string": {"query": query}}}
+
+                search_params = {
+                    "index": search_index,
+                    "body": search_body,
+                    "size": size,
+                    "timeout": timeout,
+                }
+
+                if routing:
+                    search_params["routing"] = routing
+
+                results = await self._client.search(**search_params)
+
+                if self.enable_caching:
+                    _search_cache[
+                        self._get_cache_key(query, search_index, size, timeout)
+                    ] = results
+
+                return results.raw
+
+            except (ConnectionError, RequestError) as e:
+                if attempt == self.max_retries - 1:
+                    raise
+                await asyncio.sleep(self.retry_delay * (2**attempt))
+                logger.warning(f"Search failed, attempt {attempt + 1}: {str(e)}")
+                continue
+
+    async def _run(
+        self,
+        query: str,
+        index: Optional[str] = None,
+        size: int = 10,
+        timeout: str = "30s",
+        routing: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Execute the search query."""
+
+        try:
+            results = await self._execute_search(
+                query=query, index=index, size=size, timeout=timeout, routing=routing
+            )
+            return results
+        except Exception as e:
+            logger.error(f"Error executing search: {str(e)}")
+            raise
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit."""
+        if self._client:
+            await self._client.close()
+        if self._thread_pool:
+            self._thread_pool.shutdown()
+
+    def __del__(self):
+        """Cleanup resources on deletion."""
+        try:
+            if self._client:
+                asyncio.run(self._client.close())
+            if self._thread_pool:
+                self._thread_pool.shutdown()
+        except Exception:
+            pass
+
+
+try:
+    # Only rebuild if the class hasn't been initialized yet
+    if not hasattr(ElasticsearchSearchTool, "_model_rebuilt"):
+        ElasticsearchSearchTool.model_rebuild()
+        ElasticsearchSearchTool._model_rebuilt = True
+except Exception:
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,12 +82,17 @@ snowflake = [
     "snowflake-connector-python>=3.12.4",
     "snowflake-sqlalchemy>=1.7.3",
 ]
+elasticsearch = [
+    "elasticsearch>=8.17.0",
+    "aiohttp~=3.11"
+]
 exa-py = [
     "exa-py>=1.8.7",
 ]
 qdrant-client = [
     "qdrant-client>=1.12.1",
 ]
+
 
 
 

--- a/tests/tools/elasticsearch_tool_test.py
+++ b/tests/tools/elasticsearch_tool_test.py
@@ -1,0 +1,152 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from elasticsearch import AsyncElasticsearch
+from pydantic import SecretStr
+
+from crewai_tools import ElasticsearchConfig, ElasticsearchSearchTool
+
+# Mock Response Data
+MOCK_SEARCH_RESPONSE = {
+    "hits": {
+        "total": {"value": 2, "relation": "eq"},
+        "hits": [
+            {
+                "_index": "test_index",
+                "_id": "1",
+                "_score": 1.0,
+                "_source": {"field1": "value1", "field2": 1},
+            },
+            {
+                "_index": "test_index",
+                "_id": "2",
+                "_score": 0.8,
+                "_source": {"field1": "value2", "field2": 2},
+            },
+        ],
+    }
+}
+
+
+# Unit Test Fixtures
+@pytest.fixture
+def mock_elasticsearch_client():
+    async def mock_search(*args, **kwargs):
+        return MOCK_SEARCH_RESPONSE
+
+    async def mock_close():
+        return None
+
+    mock_client = MagicMock(spec=AsyncElasticsearch)
+    mock_client.search = mock_search
+    mock_client.close = mock_close
+    return mock_client
+
+
+@pytest.fixture
+def mock_config():
+    return ElasticsearchConfig(
+        hosts=["http://localhost:9200"],
+        username="test_user",
+        password=SecretStr("test_password"),
+        default_index="test_index",
+    )
+
+
+@pytest.fixture
+def elasticsearch_tool(mock_config, mock_elasticsearch_client):
+    with patch(
+        "elasticsearch.AsyncElasticsearch", return_value=mock_elasticsearch_client
+    ):
+        tool = ElasticsearchSearchTool(config=mock_config)
+        tool._client = mock_elasticsearch_client
+        yield tool
+
+
+# Unit Tests
+@pytest.mark.asyncio
+async def test_successful_query_execution(elasticsearch_tool):
+    results = await elasticsearch_tool._run(
+        query='{"query": {"match": {"field1": "test"}}}', index="test_index", size=10
+    )
+
+    assert results == MOCK_SEARCH_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_query_string_fallback(elasticsearch_tool):
+    results = await elasticsearch_tool._run(query="field1:test", index="test_index")
+
+    assert results == MOCK_SEARCH_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_search_with_routing(elasticsearch_tool):
+    results = await elasticsearch_tool._run(
+        query="test query", index="test_index", routing="user123"
+    )
+
+    assert results == MOCK_SEARCH_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_result_caching(elasticsearch_tool):
+    elasticsearch_tool.enable_caching = True
+
+    # First call
+    results1 = await elasticsearch_tool._run(query="test query", index="test_index")
+
+    # Second call with same parameters
+    results2 = await elasticsearch_tool._run(query="test query", index="test_index")
+
+    assert results1 == results2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_on_exit(elasticsearch_tool):
+    close_called = False
+
+    async def mock_close():
+        nonlocal close_called
+        close_called = True
+
+    elasticsearch_tool._client.close = mock_close
+
+    async with elasticsearch_tool as tool:
+        await tool._run("test query")
+
+    assert close_called
+
+
+def test_config_validation():
+    # Test missing required fields
+    with pytest.raises(ValueError):
+        ElasticsearchConfig()
+
+    # Test missing both hosts and cloud_id
+    with pytest.raises(ValueError):
+        ElasticsearchConfig(username="test_user", password=SecretStr("test_pass"))
+
+    # Test valid cloud_id only configuration
+    config = ElasticsearchConfig(
+        hosts=["http://localhost:9200"],  # hosts is required even with cloud_id
+        cloud_id="test:dGVzdA==",
+        api_key=SecretStr("test_api_key"),
+    )
+    assert config.has_auth is True
+
+    # Test valid hosts configuration
+    config = ElasticsearchConfig(
+        hosts=["http://localhost:9200"],
+        username="test_user",
+        password=SecretStr("test_pass"),
+    )
+    assert config.has_auth is True
+
+
+@pytest.mark.asyncio
+async def test_missing_index_handling(elasticsearch_tool):
+    elasticsearch_tool.config.default_index = None
+
+    with pytest.raises(ValueError, match="No index specified"):
+        await elasticsearch_tool._run(query="test query")

--- a/uv.lock
+++ b/uv.lock
@@ -668,6 +668,10 @@ browserbase = [
 composio-core = [
     { name = "composio-core" },
 ]
+elasticsearch = [
+    { name = "aiohttp" },
+    { name = "elasticsearch" },
+]
 exa-py = [
     { name = "exa-py" },
 ]
@@ -725,6 +729,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", marker = "extra == 'elasticsearch'", specifier = "~=3.11" },
     { name = "beautifulsoup4", marker = "extra == 'beautifulsoup4'", specifier = ">=4.12.3" },
     { name = "browserbase", marker = "extra == 'browserbase'", specifier = ">=1.0.5" },
     { name = "chromadb", specifier = ">=0.4.22" },
@@ -733,6 +738,7 @@ requires-dist = [
     { name = "crewai", specifier = ">=0.95.0" },
     { name = "cryptography", marker = "extra == 'snowflake'", specifier = ">=43.0.3" },
     { name = "docker", specifier = ">=7.1.0" },
+    { name = "elasticsearch", marker = "extra == 'elasticsearch'", specifier = ">=8.17.0" },
     { name = "embedchain", specifier = ">=0.1.114" },
     { name = "exa-py", marker = "extra == 'exa-py'", specifier = ">=1.8.7" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl-py'", specifier = ">=1.8.0" },
@@ -883,6 +889,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/e9/f49c4e7fccb77fa5c43c2480e09a857a78b41e7331a75e128ed5df45c56b/durationpy-0.9.tar.gz", hash = "sha256:fd3feb0a69a0057d582ef643c355c40d2fa1c942191f914d12203b1a01ac722a", size = 3186 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a3/ac312faeceffd2d8f86bc6dcb5c401188ba5a01bc88e69bed97578a0dfcd/durationpy-0.9-py3-none-any.whl", hash = "sha256:e65359a7af5cedad07fb77a2dd3f390f8eb0b74cb845589fa6c057086834dd38", size = 3461 },
+]
+
+[[package]]
+name = "elastic-transport"
+version = "8.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/82/2a544ac3d9c4ae19acc7f53117251bee20dd65dc3dff01fe55ea45ae9bd9/elastic_transport-8.17.0.tar.gz", hash = "sha256:e755f38f99fa6ec5456e236b8e58f0eb18873ac8fe710f74b91a16dd562de2a5", size = 73304 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/0d/2dd25c06078070973164b661e0d79868e434998391f9aed74d4070aab270/elastic_transport-8.17.0-py3-none-any.whl", hash = "sha256:59f553300866750e67a38828fede000576562a0e66930c641adb75249e0c95af", size = 64523 },
+]
+
+[[package]]
+name = "elasticsearch"
+version = "8.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "elastic-transport" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/c2/408130a5e3b2dd7c13f9941df7886a35c7fdbb04757dec3e75f5f8b84184/elasticsearch-8.17.1.tar.gz", hash = "sha256:057ab44cae8b3acffbf826a31678e46eafc38f26fcffa91015352d973299cdf0", size = 540955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/b6/f0923ed8edddd8e70a8b5271f017944e3f24804b6d115092b97f1e9f7f51/elasticsearch-8.17.1-py3-none-any.whl", hash = "sha256:f1de0a075f12cc0fa377668eb4fb2ce02185c060ebb50cf2c3889242f9a5130e", size = 653961 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adding a tool for exploring logs in Elasticsearch, tailored for the agentic AI needs of the project I'm working on (already in production). I know there's another PR that adds an Elasticsearch tool as a RAG, but many users will need it for purposes beyond RAG, more like the Snowflake tool. I suggest adding "RAG" to the name of the other PR to differentiate them.

### Features:
Connection pooling
Cloud & self-hosted support
Authentication
Retries
Error handling


I've also added a detailed README and tests for the tool. 