### PR TITLE
Enhance Docker Security: Run Container as a Non-Root User

### DIFF
--- a/crewai_tools/tools/code_interpreter_tool/Dockerfile
+++ b/crewai_tools/tools/code_interpreter_tool/Dockerfile
@@ -1,6 +1,16 @@
 FROM python:3.12-alpine
 
-RUN pip install requests beautifulsoup4 
+# Create a non-root user and group
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 # Set the working directory
 WORKDIR /workspace
+
+# Change ownership to the non-root user
+RUN chown -R appuser:appgroup /workspace
+
+# Switch to non-root user
+USER appuser
+
+# Install dependencies (done after switching user to avoid permission issues)
+RUN pip install --no-cache-dir requests beautifulsoup4


### PR DESCRIPTION
This PR updates the Dockerfile to address a Trivy HIGH severity warning (DS002) by ensuring the container runs as a non-root user. Running containers as root poses security risks, including potential container escapes.
Changes Implemented:

    Added a new system group (appgroup) and system user (appuser).
    Set /workspace as the working directory and changed ownership to appuser.
    Switched to non-root user (USER appuser) to enhance security.
    Moved pip install after switching users to avoid permission issues.

Why This Change?

    Aligns with Docker security best practices.
    Reduces the risk of privilege escalation vulnerabilities.
    Eliminates Trivy scan failures related to running the container as root.

References:

    Fixes Trivy HIGH severity warning (DS002)
    Security best practice: [Docker Documentation](https://docs.docker.com/build/building/best-practices/)

Testing & Validation:

    The container still builds and runs as expected.
    Verified that pip install works correctly under the non-root user.
    Passed security scans without warnings.

Please review and merge to improve container security. 🚀