### PR TITLE
refactor: Update Pydantic v2 syntax and improve type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <div align="left">
 
 # **crewAI Tools**
+
 Welcome to crewAI Tools! This repository provides a comprehensive guide for setting up sophisticated tools for [crewAI](https://github.com/crewAIInc/crewAI) agents, empowering your AI solutions with bespoke tooling.
 
 In the realm of CrewAI agents, tools are pivotal for enhancing functionality. This guide outlines the steps to equip your agents with an arsenal of ready-to-use tools and the methodology to craft your own.
@@ -13,7 +14,7 @@ In the realm of CrewAI agents, tools are pivotal for enhancing functionality. Th
 
 <h3>
 
-[Homepage](https://www.crewai.io/) | [Documentation](https://docs.crewai.com/) | [Chat with Docs](https://chatg.pt/DWjSBZn) | [Examples](https://github.com/crewAIInc/crewAI-examples) | [Discord](https://discord.com/invite/X4JWnZnxPb) | [Discourse](https://community.crewai.com/)
+[Homepage](https://www.crewai.io/) | [Documentation](https://docs.crewai.com/) | [Chat with Docs](https://chatg.pt/DWjSBZn) | [Examples](https://github.com/crewAIInc/crewAI-examples) | [Community Forum](https://community.crewai.com/)
 
 </h3>
 
@@ -22,8 +23,8 @@ In the realm of CrewAI agents, tools are pivotal for enhancing functionality. Th
 ## Table of contents
 
 - [Creating Your Tools](#creating-your-tools)
-	- [Subclassing `BaseTool`](#subclassing-basetool)
-	- [Utilizing the `tool` Decorator](#utilizing-the-tool-decorator)
+  - [Subclassing `BaseTool`](#subclassing-basetool)
+  - [Utilizing the `tool` Decorator](#utilizing-the-tool-decorator)
 - [Contribution Guidelines](#contribution-guidelines)
 - [Development Setup](#development-setup)
 
@@ -45,6 +46,7 @@ For a complete list and detailed documentation of each tool, please refer to the
 Tools are always expect to return strings, as they are meant to be used by the agents to generate responses.
 
 There are three ways to create tools for crewAI agents:
+
 - [Subclassing `BaseTool`](#subclassing-basetool)
 - [Using the `tool` decorator](#utilizing-the-tool-decorator)
 
@@ -63,7 +65,6 @@ class MyCustomTool(BaseTool):
 ```
 
 Define a new class inheriting from `BaseTool`, specifying `name`, `description`, and the `_run` method for operational logic.
-
 
 ### Utilizing the `tool` Decorator
 
@@ -140,4 +141,4 @@ Thank you for your interest in enhancing the capabilities of AI agents through a
 
 ## Contact
 
-For questions or support, please join our [Discord community](https://discord.com/invite/X4JWnZnxPb), [Discourse](https://community.crewai.com/) or open an issue in this repository.
+For questions or support, please join our [Community Forum](https://community.crewai.com/) or open an issue in this repository.

--- a/crewai_tools/tools/patronus_eval_tool/patronus_local_evaluator_tool.py
+++ b/crewai_tools/tools/patronus_eval_tool/patronus_local_evaluator_tool.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, Type
 
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 if TYPE_CHECKING:
     from patronus import Client, EvaluationResult
@@ -40,8 +40,7 @@ class PatronusLocalEvaluatorTool(BaseTool):
     evaluator: str
     evaluated_model_gold_answer: str
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(
         self,

--- a/crewai_tools/tools/qdrant_vector_search_tool/qdrant_search_tool.py
+++ b/crewai_tools/tools/qdrant_vector_search_tool/qdrant_search_tool.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type, Callable
 
 
 try:
@@ -70,7 +70,7 @@ class QdrantVectorSearchTool(BaseTool):
         ...,
         description="The API key for the Qdrant server",
     )
-    custom_embedding_fn: Optional[callable] = Field(
+    custom_embedding_fn: Optional[Callable[[str], list[float]]] = Field(
         default=None,
         description="A custom embedding function to use for vectorization. If not provided, the default model will be used.",
     )

--- a/crewai_tools/tools/rag/rag_tool.py
+++ b/crewai_tools/tools/rag/rag_tool.py
@@ -2,12 +2,11 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, model_validator, ConfigDict
 
 
 class Adapter(BaseModel, ABC):
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @abstractmethod
     def query(self, question: str) -> str:

--- a/crewai_tools/tools/scrapegraph_scrape_tool/scrapegraph_scrape_tool.py
+++ b/crewai_tools/tools/scrapegraph_scrape_tool/scrapegraph_scrape_tool.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, Type, TYPE_CHECKING
 from urllib.parse import urlparse
 
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field, validator, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 
 # Type checking import
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class ScrapegraphScrapeToolSchema(FixedScrapegraphScrapeToolSchema):
         description="Prompt to guide the extraction of content",
     )
 
-    @validator("website_url")
+    @field_validator("website_url")
     def validate_url(cls, v):
         """Validate URL format"""
         try:

--- a/crewai_tools/tools/selenium_scraping_tool/selenium_scraping_tool.py
+++ b/crewai_tools/tools/selenium_scraping_tool/selenium_scraping_tool.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Type
 from urllib.parse import urlparse
 
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class FixedSeleniumScrapingToolSchema(BaseModel):
@@ -23,7 +23,7 @@ class SeleniumScrapingToolSchema(FixedSeleniumScrapingToolSchema):
         description="Mandatory css reference for element to scrape from the website",
     )
 
-    @validator("website_url")
+    @field_validator("website_url")
     def validate_website_url(cls, v):
         if not v:
             raise ValueError("Website URL cannot be empty")

--- a/crewai_tools/tools/vision_tool/vision_tool.py
+++ b/crewai_tools/tools/vision_tool/vision_tool.py
@@ -4,7 +4,7 @@ from typing import Optional, Type
 
 from crewai.tools import BaseTool
 from openai import OpenAI
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 
 class ImagePromptSchema(BaseModel):
@@ -12,7 +12,7 @@ class ImagePromptSchema(BaseModel):
 
     image_path_url: str = "The image path or URL."
 
-    @validator("image_path_url")
+    @field_validator("image_path_url")
     def validate_image_path_url(cls, v: str) -> str:
         if v.startswith("http"):
             return v


### PR DESCRIPTION
# Pydantic v2 Updates and Type Hint Improvements

## Changes Made
1. Updated Pydantic v2 syntax:
   - Replaced `Config` class with `model_config = ConfigDict` in multiple tools
   - Updated `validator` decorator to `field_validator` for schema validation
   - Fixed deprecated syntax across the codebase

2. Improved type hints:
   - Enhanced `custom_embedding_fn` type in QdrantVectorSearchTool from `callable` to `Callable[[str], list[float]]`
   - Added proper type imports across tools

3. Documentation improvements:
   - Updated README.md links and formatting
   - Improved table of contents structure

## Testing
- All tests pass except for known issues with Snowflake integration tests and Spider tool tests (which require API keys)
- No new test failures introduced by these changes

## Impact
These changes ensure compatibility with Pydantic v2 and improve type safety across the codebase without introducing breaking changes.