### PR TITLE
Fix: FirecrawlCrawlWebsiteTool update parameters for FireCrawl API v1 and update run arguments for agents

### DIFF
--- a/crewai_tools/tools/firecrawl_crawl_website_tool/README.md
+++ b/crewai_tools/tools/firecrawl_crawl_website_tool/README.md
@@ -4,6 +4,10 @@
 
 [Firecrawl](https://firecrawl.dev) is a platform for crawling and convert any website into clean markdown or structured data.
 
+## Version Compatibility
+
+This implementation is compatible with FireCrawl API v1
+
 ## Installation
 
 - Get an API key from [firecrawl.dev](https://firecrawl.dev) and set it in environment variables (`FIRECRAWL_API_KEY`).
@@ -27,13 +31,27 @@ tool = FirecrawlCrawlWebsiteTool(url='firecrawl.dev')
 
 - `api_key`: Optional. Specifies Firecrawl API key. Defaults is the `FIRECRAWL_API_KEY` environment variable.
 - `url`: The base URL to start crawling from.
-- `page_options`: Optional. 
-  - `onlyMainContent`: Optional. Only return the main content of the page excluding headers, navs, footers, etc.
-  - `includeHtml`: Optional. Include the raw HTML content of the page. Will output a html key in the response.
-- `crawler_options`: Optional. Options for controlling the crawling behavior.
-  - `maxDepth`: Optional. Maximum depth to crawl. Depth 1 is the base URL, depth 2 includes the base URL and its direct children and so on.
-  - `limit`: Optional. Maximum number of pages to crawl.
-  - `scrapeOptions`: Optional. Additional options for controlling the crawler.
-    - `formats`: Optional. Formats for the page's content to be returned (eg. markdown, html, screenshot, links).
-    - `timeout`: Optional. Timeout in milliseconds for the crawling operation.
+- `maxDepth`: Optional. Maximum depth to crawl. Depth 1 is the base URL, depth 2 includes the base URL and its direct children and so on.  
+- `limit`: Optional. Maximum number of pages to crawl.  
+- `allowExternalLinks`: Allows the crawler to follow links that point to external domains.  
+- `formats`: Optional. Formats for the page's content to be returned (eg. markdown, html, screenshot, links).  
+- `timeout`: Optional. Timeout in milliseconds for the crawling operation.  
 
+## Configurations Example
+
+This is the default configuration
+
+```python
+    DEFAULT_CRAWLING_OPTIONS = {
+        "maxDepth": 2,
+        "ignoreSitemap": True,
+        "limit": 100,
+        "allowBackwardLinks": False, 
+        "allowExternalLinks": False,
+        "scrapeOptions": {
+            "formats": ["markdown", "screenshot", "links"],
+            "onlyMainContent": True,
+            "timeout": 30000
+        }
+    }
+```

--- a/crewai_tools/tools/firecrawl_crawl_website_tool/README.md
+++ b/crewai_tools/tools/firecrawl_crawl_website_tool/README.md
@@ -31,12 +31,9 @@ tool = FirecrawlCrawlWebsiteTool(url='firecrawl.dev')
   - `onlyMainContent`: Optional. Only return the main content of the page excluding headers, navs, footers, etc.
   - `includeHtml`: Optional. Include the raw HTML content of the page. Will output a html key in the response.
 - `crawler_options`: Optional. Options for controlling the crawling behavior.
-  - `includes`: Optional. URL patterns to include in the crawl.
-  - `exclude`: Optional. URL patterns to exclude from the crawl.
-  - `generateImgAltText`: Optional. Generate alt text for images using LLMs (requires a paid plan).
-  - `returnOnlyUrls`: Optional. If true, returns only the URLs as a list in the crawl status. Note: the response will be a list of URLs inside the data, not a list of documents.
-  - `maxDepth`: Optional. Maximum depth to crawl. Depth 1 is the base URL, depth 2 includes the base URL and its direct children, and so on.
-  - `mode`: Optional. The crawling mode to use. Fast mode crawls 4x faster on websites without a sitemap but may not be as accurate and shouldn't be used on heavily JavaScript-rendered websites.
+  - `maxDepth`: Optional. Maximum depth to crawl. Depth 1 is the base URL, depth 2 includes the base URL and its direct children and so on.
   - `limit`: Optional. Maximum number of pages to crawl.
-  - `timeout`: Optional. Timeout in milliseconds for the crawling operation.
+  - `scrapeOptions`: Optional. Additional options for controlling the crawler.
+    - `formats`: Optional. Formats for the page's content to be returned (eg. markdown, html, screenshot, links).
+    - `timeout`: Optional. Timeout in milliseconds for the crawling operation.
 

--- a/crewai_tools/tools/firecrawl_crawl_website_tool/firecrawl_crawl_website_tool.py
+++ b/crewai_tools/tools/firecrawl_crawl_website_tool/firecrawl_crawl_website_tool.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Type
+from typing import Any, Optional, Type
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
@@ -14,16 +14,19 @@ class FirecrawlCrawlWebsiteToolSchema(BaseModel):
     url: str = Field(description="Website URL")
     maxDepth: Optional[int] = Field(
         default=2,
-        description="Maximum depth to crawl. Depth 1 is the base URL, depth 2 includes the base URL and its direct children and so on.")
+        description="Maximum depth to crawl. Depth 1 is the base URL, depth 2 includes the base URL and its direct children and so on.",
+    )
     limit: Optional[int] = Field(
-        default=100,
-        description="Maximum number of pages to crawl.")
+        default=100, description="Maximum number of pages to crawl."
+    )
     allowExternalLinks: Optional[bool] = Field(
         default=False,
-        description="Allows the crawler to follow links that point to external domains.")
+        description="Allows the crawler to follow links that point to external domains.",
+    )
     formats: Optional[list[str]] = Field(
         default=["markdown", "screenshot", "links"],
-        description="Formats for the page's content to be returned (eg. markdown, html, screenshot, links).")
+        description="Formats for the page's content to be returned (eg. markdown, html, screenshot, links).",
+    )
     timeout: Optional[int] = Field(
         default=30000,
         description="Timeout in milliseconds for the crawling operation. The default value is 30000.",
@@ -39,7 +42,6 @@ class FirecrawlCrawlWebsiteTool(BaseTool):
     args_schema: Type[BaseModel] = FirecrawlCrawlWebsiteToolSchema
     api_key: Optional[str] = None
     _firecrawl: Optional["FirecrawlApp"] = PrivateAttr(None)
-    
 
     def __init__(self, api_key: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
@@ -91,20 +93,20 @@ class FirecrawlCrawlWebsiteTool(BaseTool):
             "scrapeOptions": {
                 "formats": ["markdown", "screenshot", "links"],
                 "onlyMainContent": True,
-                "timeout": DEFAULT_TIMEOUT
-            }
+                "timeout": DEFAULT_TIMEOUT,
+            },
         }
-        
+
         # Add default options not present as parameters
         crawling_options = DEFAULT_CRAWLING_OPTIONS
-        
+
         # Update the values of parameters present
         crawling_options["maxDepth"] = maxDepth
         crawling_options["limit"] = limit
         crawling_options["allowExternalLinks"] = allowExternalLinks
         crawling_options["scrapeOptions"]["formats"] = formats
         crawling_options["scrapeOptions"]["timeout"] = timeout
-        
+
         return self._firecrawl.crawl_url(url, crawling_options)
 
 

--- a/crewai_tools/tools/firecrawl_crawl_website_tool/firecrawl_crawl_website_tool.py
+++ b/crewai_tools/tools/firecrawl_crawl_website_tool/firecrawl_crawl_website_tool.py
@@ -68,13 +68,22 @@ class FirecrawlCrawlWebsiteTool(BaseTool):
         timeout: Optional[int] = 30000,
     ):
         if crawler_options is None:
-            crawler_options = {}
+            crawler_options = {
+                                "maxDepth": 2,
+                                "limit": 10,
+                                "scrapeOptions": {
+                                    # same options as in /scrape
+                                    "formats": ["markdown", "screenshot", "links"],
+                                    "timeout": timeout
+                                    }
+                                }
 
-        options = {
-            "crawlerOptions": crawler_options,
-            "timeout": timeout,
-        }
-        return self._firecrawl.crawl_url(url, options)
+        
+        else:
+            crawler_options["scrapeOptions"]["timeout"] = timeout
+
+        
+        return self._firecrawl.crawl_url(url, crawler_options)
 
 
 try:


### PR DESCRIPTION
FireCrawl API does not recognize sent parameters as this error describes:

``` terminal
HTTPError: Unexpected error during start crawl job: Status code 400. Bad Request -
[{'code': 'unrecognized_keys', 'keys': ['crawlerOptions', 'timeout'], 'path': [], 'message': 'Unrecognized key in body -- please review the v1 API documentation for request body changes'}]
```
Because FireCrawl API has been updated to v1. I updated the tool parameters to match v1 and updated their description in the ReadMe file
