### PR TITLE
fix: replace deperecated validator with field_validator

### DIFF
--- a/crewai_tools/tools/scrapegraph_scrape_tool/scrapegraph_scrape_tool.py
+++ b/crewai_tools/tools/scrapegraph_scrape_tool/scrapegraph_scrape_tool.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, Type, TYPE_CHECKING
 from urllib.parse import urlparse
 
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field, validator, ConfigDict
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 # Type checking import
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class ScrapegraphScrapeToolSchema(FixedScrapegraphScrapeToolSchema):
         description="Prompt to guide the extraction of content",
     )
 
-    @validator("website_url")
+    @field_validator("website_url")
     def validate_url(cls, v):
         """Validate URL format"""
         try:

--- a/crewai_tools/tools/selenium_scraping_tool/selenium_scraping_tool.py
+++ b/crewai_tools/tools/selenium_scraping_tool/selenium_scraping_tool.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Type
 from urllib.parse import urlparse
 
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class FixedSeleniumScrapingToolSchema(BaseModel):
@@ -23,7 +23,7 @@ class SeleniumScrapingToolSchema(FixedSeleniumScrapingToolSchema):
         description="Mandatory css reference for element to scrape from the website",
     )
 
-    @validator("website_url")
+    @field_validator("website_url")
     def validate_website_url(cls, v):
         if not v:
             raise ValueError("Website URL cannot be empty")

--- a/crewai_tools/tools/vision_tool/vision_tool.py
+++ b/crewai_tools/tools/vision_tool/vision_tool.py
@@ -4,7 +4,7 @@ from typing import Optional, Type
 
 from crewai.tools import BaseTool
 from openai import OpenAI
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 
 class ImagePromptSchema(BaseModel):
@@ -12,7 +12,7 @@ class ImagePromptSchema(BaseModel):
 
     image_path_url: str = "The image path or URL."
 
-    @validator("image_path_url")
+    @field_validator("image_path_url")
     def validate_image_path_url(cls, v: str) -> str:
         if v.startswith("http"):
             return v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "embedchain>=0.1.114",
     "crewai>=0.105.0",
     "click>=8.1.8",
+    "lancedb>=0.5.4",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "embedchain>=0.1.114",
     "crewai>=0.105.0",
     "click>=8.1.8",
-    "lancedb>=0.5.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
I'm currently receiving these warnings while using the tools package

```zsh
PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
  @validator("website_url")
  ```
  
  this PR fixes these warnings