### PR TITLE
cleanup more warnings from tools

### DIFF
--- a/crewai_tools/tools/databricks_query_tool/databricks_query_tool.py
+++ b/crewai_tools/tools/databricks_query_tool/databricks_query_tool.py
@@ -16,7 +16,7 @@ class DatabricksQueryToolSchema(BaseModel):
     catalog: Optional[str] = Field(
         None, description="Databricks catalog name (optional, defaults to configured catalog)"
     )
-    schema: Optional[str] = Field(
+    db_schema: Optional[str] = Field(
         None, description="Databricks schema name (optional, defaults to configured schema)"
     )
     warehouse_id: Optional[str] = Field(
@@ -168,7 +168,7 @@ class DatabricksQueryTool(BaseTool):
         Args:
             query (str): SQL query to execute
             catalog (Optional[str]): Databricks catalog name
-            schema (Optional[str]): Databricks schema name
+            db_schema (Optional[str]): Databricks schema name
             warehouse_id (Optional[str]): SQL warehouse ID
             row_limit (Optional[int]): Maximum number of rows to return
 
@@ -179,7 +179,7 @@ class DatabricksQueryTool(BaseTool):
             # Get parameters with fallbacks to default values
             query = kwargs.get("query")
             catalog = kwargs.get("catalog") or self.default_catalog
-            schema = kwargs.get("schema") or self.default_schema
+            db_schema = kwargs.get("db_schema") or self.default_schema
             warehouse_id = kwargs.get("warehouse_id") or self.default_warehouse_id
             row_limit = kwargs.get("row_limit", 1000)
 
@@ -187,7 +187,7 @@ class DatabricksQueryTool(BaseTool):
             validated_input = DatabricksQueryToolSchema(
                 query=query,
                 catalog=catalog,
-                schema=schema,
+                db_schema=db_schema,
                 warehouse_id=warehouse_id,
                 row_limit=row_limit
             )
@@ -195,15 +195,15 @@ class DatabricksQueryTool(BaseTool):
             # Extract validated parameters
             query = validated_input.query
             catalog = validated_input.catalog
-            schema = validated_input.schema
+            db_schema = validated_input.db_schema
             warehouse_id = validated_input.warehouse_id
 
             # Setup SQL context with catalog/schema if provided
             context = {}
             if catalog:
                 context["catalog"] = catalog
-            if schema:
-                context["schema"] = schema
+            if db_schema:
+                context["schema"] = db_schema
 
             # Execute query
             statement = self.workspace_client.statement_execution


### PR DESCRIPTION
rename schema to db_schema in DatabricksQueryTool to resolve:

```sh
crewAI % python src/crewai/runner.py
/Users/lorenzejay/workspace/crewAI/.venv/lib/python3.12/site-packages/pydantic/_internal/_fields.py:172: UserWarning: Field name "schema" in "DatabricksQueryToolSchema" shadows an attribute in parent "BaseModel"
  warnings.warn(
/Users/lorenzejay/workspace/crewAI/.venv/lib/python3.12/site-packages/pydantic/_internal/_generate_schema.py:547: UserWarning: <built-in function callable> is not a Python type (it may be an instance of an object), Pydantic will allow any object with no validation since we cannot even enforce that the input is an instance of the given type. To get rid of this error wrap the type with `pydantic.SkipValidation`.
  warn(
  ```