### PR TITLE
Replace distutils with setuptools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: 23.12.1
     hooks:
       - id: black
-        language_version: python3.11
+        language_version: python3.12
         files: \.(py)$
 
   - repo: https://github.com/pycqa/isort

--- a/crewai_tools/tools/file_writer_tool/file_writer_tool.py
+++ b/crewai_tools/tools/file_writer_tool/file_writer_tool.py
@@ -1,9 +1,9 @@
 import os
-from distutils.util import strtobool
 from typing import Any, Optional, Type
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel
+from setuptools._distutils.util import strtobool
 
 
 class FileWriterToolInput(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "crewai>=0.105.0",
     "click>=8.1.8",
     "lancedb>=0.5.4",
+    "setuptools>=78.1.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -681,6 +681,7 @@ dependencies = [
     { name = "pyright" },
     { name = "pytube" },
     { name = "requests" },
+    { name = "setuptools" },
 ]
 
 [package.optional-dependencies]
@@ -790,6 +791,7 @@ requires-dist = [
     { name = "scrapfly-sdk", marker = "extra == 'scrapfly-sdk'", specifier = ">=0.8.19" },
     { name = "selenium", marker = "extra == 'selenium'", specifier = ">=4.27.1" },
     { name = "serpapi", marker = "extra == 'serpapi'", specifier = ">=0.1.5" },
+    { name = "setuptools", specifier = ">=78.1.0" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.12.4" },
     { name = "snowflake-sqlalchemy", marker = "extra == 'snowflake'", specifier = ">=1.7.3" },
     { name = "spider-client", marker = "extra == 'spider-client'", specifier = ">=0.1.25" },
@@ -4303,11 +4305,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "75.8.0"
+version = "78.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/ec/089608b791d210aec4e7f97488e67ab0d33add3efccb83a056cbafe3a2a6/setuptools-75.8.0.tar.gz", hash = "sha256:c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6", size = 1343222 }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54", size = 1367827 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/8a/b9dc7678803429e4a3bc9ba462fa3dd9066824d3c607490235c6a796be5a/setuptools-75.8.0-py3-none-any.whl", hash = "sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3", size = 1228782 },
+    { url = "https://files.pythonhosted.org/packages/54/21/f43f0a1fa8b06b32812e0975981f4677d28e0f3271601dc88ac5a5b83220/setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8", size = 1256108 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
This PR replaces usage of deprecated `distutils` with `setuptools` in the codebase.

## Why?
The `distutils` package is deprecated since Python 3.10 and scheduled for removal in Python 3.12. Replacing it with `setuptools` ensures compatibility with newer Python versions.

## Changes
- Updated code that used `distutils` to use equivalent functionality from `setuptools`
- Ensured backward compatibility is maintained
- Updated relevant imports

## Related Issues
N/A

## Additional Notes
This is a maintenance PR to prevent future deprecation warnings and ensure compatibility with Python 3.12+.