### PR TITLE
Fix FirecrawlScrapeWebsiteTool

### DIFF
--- a/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
+++ b/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
@@ -49,9 +49,7 @@ class FirecrawlScrapeWebsiteTool(BaseTool):
 
     _firecrawl: Optional["FirecrawlApp"] = PrivateAttr(None)
 
-    def __init__(self, api_key: Optional[str] = None, config: Dict[str, Any] = None, **kwargs):
-        if config:
-            kwargs["config"] = config
+    def __init__(self, api_key: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
         try:
             from firecrawl import FirecrawlApp  # type: ignore

--- a/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
+++ b/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
@@ -10,11 +10,6 @@ except ImportError:
 
 class FirecrawlScrapeWebsiteToolSchema(BaseModel):
     url: str = Field(description="Website URL")
-    timeout: Optional[int] = Field(
-        default=30000,
-        description="Timeout in milliseconds for the scraping operation. The default value is 30000.",
-    )
-
 
 class FirecrawlScrapeWebsiteTool(BaseTool):
     """
@@ -54,7 +49,7 @@ class FirecrawlScrapeWebsiteTool(BaseTool):
 
     _firecrawl: Optional["FirecrawlApp"] = PrivateAttr(None)
 
-    def __init__(self, api_key: Optional[str] = None, config: Optional[Dict[str, Any]] = None, **kwargs):
+    def __init__(self, api_key: Optional[str] = None, config: Dict[str, Any] = None, **kwargs):
         if config:
             kwargs["config"] = config
         super().__init__(**kwargs)

--- a/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
+++ b/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
@@ -72,7 +72,7 @@ class FirecrawlScrapeWebsiteTool(BaseTool):
 
         self._firecrawl = FirecrawlApp(api_key=api_key)
 
-    def _run(self, url: str, timeout: Optional[int] = 30000):
+    def _run(self, url: str):
         return self._firecrawl.scrape_url(url, **self.config)
 
 


### PR DESCRIPTION
Add missing config parameter and correct Dict type annotation
- Add required config parameter when creating the tool
- Change type hint from `dict` to `Dict` to resolve Pydantic validation issues