### PR TITLE
Fix `Callable` reference in QdrantVectorSearchTool

### DIFF
--- a/crewai_tools/tools/qdrant_vector_search_tool/qdrant_search_tool.py
+++ b/crewai_tools/tools/qdrant_vector_search_tool/qdrant_search_tool.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Optional, Type
+from typing import Any, Callable, Optional, Type
 
 
 try:
@@ -70,7 +70,7 @@ class QdrantVectorSearchTool(BaseTool):
         default=None,
         description="The API key for the Qdrant server",
     )
-    custom_embedding_fn: Optional[callable] = Field(
+    custom_embedding_fn: Optional[Callable] = Field(
         default=None,
         description="A custom embedding function to use for vectorization. If not provided, the default model will be used.",
     )


### PR DESCRIPTION
The built-in `callable` type is not subscriptable, and thus not usable in a type annotation. When this tool is used, this warning is generated:

```
.../_generate_schema.py:623: UserWarning: <built-in function callable> is not a Python type (it may be an instance of an object), Pydantic will allow any object with no validation since we cannot even enforce that the input is an instance of the given type. To get rid of this error wrap the type with `pydantic.SkipValidation`.
```

This change fixes the warning.