### PR TITLE
Introduce Firecrawl api-url variable in initialisation of associated tools

### DIFF
--- a/crewai_tools/tools/firecrawl_crawl_website_tool/README.md
+++ b/crewai_tools/tools/firecrawl_crawl_website_tool/README.md
@@ -38,6 +38,7 @@ tool.run(url="firecrawl.dev")
 ## Arguments
 
 - `api_key`: Optional. Specifies Firecrawl API key. Defaults is the `FIRECRAWL_API_KEY` environment variable.
+- `api_url`: Optional. The Firecrawl endpoint. Defaults to the value of the `FIRECRAWL_API_URL` environment variable, or falls back to "https://api.firecrawl.dev" if unset.
 - `config`: Optional. It contains Firecrawl API parameters.
 
 This is the default configuration

--- a/crewai_tools/tools/firecrawl_crawl_website_tool/firecrawl_crawl_website_tool.py
+++ b/crewai_tools/tools/firecrawl_crawl_website_tool/firecrawl_crawl_website_tool.py
@@ -19,6 +19,7 @@ class FirecrawlCrawlWebsiteTool(BaseTool):
 
     Args:
         api_key (str): Your Firecrawl API key.
+        api_url (str): The Firecrawl endpoint.
         config (dict): Optional. It contains Firecrawl API parameters.
 
     Default configuration options:
@@ -40,6 +41,7 @@ class FirecrawlCrawlWebsiteTool(BaseTool):
     description: str = "Crawl webpages using Firecrawl and return the contents"
     args_schema: Type[BaseModel] = FirecrawlCrawlWebsiteToolSchema
     api_key: Optional[str] = None
+    api_url: Optional[str] = None
     config: Optional[dict[str, Any]] = Field(
         default_factory=lambda: {
             "max_depth": 2,
@@ -56,35 +58,27 @@ class FirecrawlCrawlWebsiteTool(BaseTool):
     )
     _firecrawl: Optional["FirecrawlApp"] = PrivateAttr(None)
 
-    def __init__(self, api_key: Optional[str] = None, **kwargs):
+    def __init__(self, api_key: Optional[str] = None, api_url: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
         self.api_key = api_key
-        self._initialize_firecrawl()
-
-    def _initialize_firecrawl(self) -> None:
+        self.api_url = api_url
         try:
             from firecrawl import FirecrawlApp  # type: ignore
-
-            self._firecrawl = FirecrawlApp(api_key=self.api_key)
         except ImportError:
-            import click
-
+            import click, subprocess
             if click.confirm(
                 "You are missing the 'firecrawl-py' package. Would you like to install it?"
             ):
-                import subprocess
-
                 try:
                     subprocess.run(["uv", "add", "firecrawl-py"], check=True)
                     from firecrawl import FirecrawlApp
-
-                    self._firecrawl = FirecrawlApp(api_key=self.api_key)
                 except subprocess.CalledProcessError:
                     raise ImportError("Failed to install firecrawl-py package")
             else:
                 raise ImportError(
                     "`firecrawl-py` package not found, please run `uv add firecrawl-py`"
                 )
+        self._firecrawl = FirecrawlApp(api_key=self.api_key, api_url=self.api_url)
 
     def _run(self, url: str):
         return self._firecrawl.crawl_url(url, **self.config)

--- a/crewai_tools/tools/firecrawl_scrape_website_tool/README.md
+++ b/crewai_tools/tools/firecrawl_scrape_website_tool/README.md
@@ -27,6 +27,7 @@ tool.run(url="firecrawl.dev")
 ## Arguments
 
 - `api_key`: Optional. Specifies Firecrawl API key. Defaults is the `FIRECRAWL_API_KEY` environment variable.
+- `api_url`: Optional. The Firecrawl endpoint. Defaults to the value of the `FIRECRAWL_API_URL` environment variable, or falls back to "https://api.firecrawl.dev" if unset.
 - `config`: Optional. It contains Firecrawl API parameters.
 
 

--- a/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
+++ b/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Optional, Type, Dict
 
 from crewai.tools import BaseTool
@@ -17,6 +18,7 @@ class FirecrawlScrapeWebsiteTool(BaseTool):
 
     Args:
         api_key (str): Your Firecrawl API key.
+        api_url (str): The Firecrawl endpoint.
         config (dict): Optional. It contains Firecrawl API parameters.
 
     Default configuration options:
@@ -36,6 +38,7 @@ class FirecrawlScrapeWebsiteTool(BaseTool):
     description: str = "Scrape webpages using Firecrawl and return the contents"
     args_schema: Type[BaseModel] = FirecrawlScrapeWebsiteToolSchema
     api_key: Optional[str] = None
+    api_url: Optional[str] = None
     config: Dict[str, Any] = Field(
         default_factory=lambda: {
             "formats": ["markdown"],
@@ -49,28 +52,27 @@ class FirecrawlScrapeWebsiteTool(BaseTool):
 
     _firecrawl: Optional["FirecrawlApp"] = PrivateAttr(None)
 
-    def __init__(self, api_key: Optional[str] = None, **kwargs):
+    def __init__(self, api_key: Optional[str] = None, api_url: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
+        self.api_key = api_key
+        self.api_url = api_url
         try:
             from firecrawl import FirecrawlApp  # type: ignore
         except ImportError:
-            import click
-
+            import click, subprocess
             if click.confirm(
                 "You are missing the 'firecrawl-py' package. Would you like to install it?"
             ):
-                import subprocess
-
-                subprocess.run(["uv", "add", "firecrawl-py"], check=True)
-                from firecrawl import (
-                    FirecrawlApp,
-                )
+                try:
+                    subprocess.run(["uv", "add", "firecrawl-py"], check=True)
+                    from firecrawl import FirecrawlApp
+                except subprocess.CalledProcessError:
+                    raise ImportError("Failed to install firecrawl-py package")
             else:
                 raise ImportError(
                     "`firecrawl-py` package not found, please run `uv add firecrawl-py`"
                 )
-
-        self._firecrawl = FirecrawlApp(api_key=api_key)
+        self._firecrawl = FirecrawlApp(api_key=self.api_key, api_url=self.api_url)
 
     def _run(self, url: str):
         return self._firecrawl.scrape_url(url, **self.config)

--- a/crewai_tools/tools/firecrawl_search_tool/README.md
+++ b/crewai_tools/tools/firecrawl_search_tool/README.md
@@ -27,6 +27,7 @@ tool.run(query="firecrawl web scraping")
 ## Arguments
 
 - `api_key`: Optional. Specifies Firecrawl API key. Defaults is the `FIRECRAWL_API_KEY` environment variable.
+- `api_url`: Optional. The Firecrawl endpoint. Defaults to the value of the `FIRECRAWL_API_URL` environment variable, or falls back to "https://api.firecrawl.dev" if unset.
 - `config`: Optional. It contains Firecrawl API parameters.
 
 


### PR DESCRIPTION
## What this PR does
- Updates firecrawl class to include api_url in instantiation, mirroring underlying FirecrawlApp class behaviour.


## Why include this? 
- To enable crewAI firecrawl tools to easily use firecrawl's self and local hosting options.
- Currently can set the env var FIRECRAWL_API_URL and the FirecrawlApp class will use it, however this is not surfaced in the crewAI docs or the tool's class initialiser.

## Why not include this in the existing 'config' variable within crewAI's existing Firecrawl tools. 
- The config variable in is associated with the relevant Firecrawl methods, e.g. `scrape_url`, `crawl_url`, etc,  not the instantiation of the FirecrawlApp class. However, the `api_key` and the `api_url` are.

## Why has the error handling changed? 
- The associated firecrawl tools had inconsistent error handling around the missing package `firecrawl-py`. This change just standardises it. 
- Also removes the try/except around the firecrawl-py installation attempt. This is to not obfuscate the actual error message with "Failed to install firecrawl-py package".