### PR TITLE
fix: ensure the entire file will be read when the start_line is None

### DIFF
--- a/crewai_tools/tools/file_read_tool/file_read_tool.py
+++ b/crewai_tools/tools/file_read_tool/file_read_tool.py
@@ -59,11 +59,13 @@ class FileReadTool(BaseTool):
 
     def _run(
         self,
-        **kwargs: Any,
+        file_path: Optional[str] = None,
+        start_line: Optional[int] = 1,
+        line_count: Optional[int] = None,
     ) -> str:
-        file_path = kwargs.get("file_path", self.file_path)
-        start_line = kwargs.get("start_line", 1)
-        line_count = kwargs.get("line_count", None)
+        file_path = file_path or self.file_path
+        start_line = start_line or 1
+        line_count = line_count or None
 
         if file_path is None:
             return (

--- a/tests/file_read_tool_test.py
+++ b/tests/file_read_tool_test.py
@@ -139,6 +139,11 @@ def test_file_read_tool_zero_or_negative_start_line():
     with patch("builtins.open", mock_open(read_data=file_content)):
         tool = FileReadTool()
 
+        # Test with start_line = None
+        result = tool._run(file_path=test_file, start_line=None)
+        expected = "".join(lines)  # Should read the entire file
+        assert result == expected
+
         # Test with start_line = 0
         result = tool._run(file_path=test_file, start_line=0)
         expected = "".join(lines)  # Should read the entire file


### PR DESCRIPTION
Closes https://github.com/crewAIInc/crewAI/issues/2753

Quick fix to prevent FileReadTool break when the Agent call this with with `start_line: null` paramenter

``` 
## Using tool: Read a file's content
## Tool Input: 
"{\"file_path\": \"./file.md\", \"start_line\": null, \"line_count\": null}"
## Tool Output: 
Error: Failed to read file ./file.md. unsupported operand type(s) for -: 'NoneType' and 'int'
```