### PR TITLE
refactor: remove token validation from EnterpriseActionKitToolAdapter…

### DIFF
--- a/crewai_tools/adapters/enterprise_adapter.py
+++ b/crewai_tools/adapters/enterprise_adapter.py
@@ -125,8 +125,6 @@ class EnterpriseActionKitToolAdapter:
         enterprise_action_kit_project_id: str = ENTERPRISE_ACTION_KIT_PROJECT_ID,
     ):
         """Initialize the adapter with an enterprise action token."""
-        if not enterprise_action_token:
-            raise ValueError("enterprise_action_token is required")
 
         self.enterprise_action_token = enterprise_action_token
         self._actions_schema = {}

--- a/crewai_tools/tools/crewai_enterprise_tools/crewai_enterprise_tools.py
+++ b/crewai_tools/tools/crewai_enterprise_tools/crewai_enterprise_tools.py
@@ -27,10 +27,6 @@ def CrewaiEnterpriseTools(
     """
     if enterprise_token is None:
         enterprise_token = os.environ.get("CREWAI_ENTEPRISE_TOOLS_TOKEN")
-        if enterprise_token is None:
-            raise ValueError(
-                "No enterprise token provided. Please provide a token or set the CREWAI_ENTEPRISE_TOOLS_TOKEN environment variable."
-            )
 
     adapter_kwargs = {"enterprise_action_token": enterprise_token}
 

--- a/crewai_tools/tools/crewai_enterprise_tools/crewai_enterprise_tools.py
+++ b/crewai_tools/tools/crewai_enterprise_tools/crewai_enterprise_tools.py
@@ -4,8 +4,11 @@ Crewai Enterprise Tools
 
 import os
 import typing as t
+import logging
 from crewai.tools import BaseTool
 from crewai_tools.adapters.enterprise_adapter import EnterpriseActionKitToolAdapter
+
+logger = logging.getLogger(__name__)
 
 
 def CrewaiEnterpriseTools(
@@ -27,6 +30,7 @@ def CrewaiEnterpriseTools(
     """
     if enterprise_token is None:
         enterprise_token = os.environ.get("CREWAI_ENTEPRISE_TOOLS_TOKEN")
+        logger.warning("No enterprise token provided")
 
     adapter_kwargs = {"enterprise_action_token": enterprise_token}
 

--- a/crewai_tools/tools/crewai_enterprise_tools/crewai_enterprise_tools.py
+++ b/crewai_tools/tools/crewai_enterprise_tools/crewai_enterprise_tools.py
@@ -21,7 +21,7 @@ def CrewaiEnterpriseTools(
 
     Args:
         enterprise_token: The token for accessing enterprise actions.
-                         If not provided, will try to use CREWAI_ENTEPRISE_TOOLS_TOKEN env var.
+                         If not provided, will try to use CREWAI_ENTERPRISE_TOOLS_TOKEN env var.
         actions_list: Optional list of specific tool names to include.
                    If provided, only tools with these names will be returned.
 
@@ -29,7 +29,7 @@ def CrewaiEnterpriseTools(
         A list of BaseTool instances for enterprise actions
     """
     if enterprise_token is None:
-        enterprise_token = os.environ.get("CREWAI_ENTEPRISE_TOOLS_TOKEN")
+        enterprise_token = os.environ.get("CREWAI_ENTERPRISE_TOOLS_TOKEN")
         logger.warning("No enterprise token provided")
 
     adapter_kwargs = {"enterprise_action_token": enterprise_token}


### PR DESCRIPTION
… and CrewaiEnterpriseTools

This commit simplifies the initialization of the EnterpriseActionKitToolAdapter and CrewaiEnterpriseTools by removing the explicit validation for the enterprise action token. The token can now be set to None without raising an error, allowing for more flexible usage.