### PR TITLE
fix: update Pydantic schema access

### DIFF
--- a/tests/base_tool_test.py
+++ b/tests/base_tool_test.py
@@ -16,7 +16,7 @@ def test_creating_a_tool_using_annotation():
         my_tool.description
         == "Tool Name: Name of my tool\nTool Arguments: {'question': {'description': None, 'type': 'str'}}\nTool Description: Clear description for what this tool is useful for, you agent will need this information to use it."
     )
-    assert my_tool.args_schema.schema()["properties"] == {
+    assert my_tool.args_schema.model_json_schema()["properties"] == {
         "question": {"title": "Question", "type": "string"}
     }
     assert (
@@ -30,7 +30,7 @@ def test_creating_a_tool_using_annotation():
         converted_tool.description
         == "Tool Name: Name of my tool\nTool Arguments: {'question': {'description': None, 'type': 'str'}}\nTool Description: Clear description for what this tool is useful for, you agent will need this information to use it."
     )
-    assert converted_tool.args_schema.schema()["properties"] == {
+    assert converted_tool.args_schema.model_json_schema()["properties"] == {
         "question": {"title": "Question", "type": "string"}
     }
     assert (
@@ -54,7 +54,7 @@ def test_creating_a_tool_using_baseclass():
         my_tool.description
         == "Tool Name: Name of my tool\nTool Arguments: {'question': {'description': None, 'type': 'str'}}\nTool Description: Clear description for what this tool is useful for, you agent will need this information to use it."
     )
-    assert my_tool.args_schema.schema()["properties"] == {
+    assert my_tool.args_schema.model_json_schema()["properties"] == {
         "question": {"title": "Question", "type": "string"}
     }
     assert (
@@ -68,7 +68,7 @@ def test_creating_a_tool_using_baseclass():
         converted_tool.description
         == "Tool Name: Name of my tool\nTool Arguments: {'question': {'description': None, 'type': 'str'}}\nTool Description: Clear description for what this tool is useful for, you agent will need this information to use it."
     )
-    assert converted_tool.args_schema.schema()["properties"] == {
+    assert converted_tool.args_schema.model_json_schema()["properties"] == {
         "question": {"title": "Question", "type": "string"}
     }
     assert (


### PR DESCRIPTION
## PR Summary
This small PR updates schema serialization access patterns within the test suite to comply with the Pydantic V2 API and resolve `PydanticDeprecatedSince20` warnings. Specifically:

- Replaced deprecated `.schema()` calls with `.model_json_schema()` on Pydantic models in `tests/base_tool_test.py`.

These changes ensure forward compatibility with Pydantic V2+ and resolve warnings about `.schema()` deprecation, as seen in the [CI logs](https://github.com/crewAIInc/crewAI-tools/actions/runs/15682951402/job/44178762635#step:6:116):
```python
/home/runner/work/crewAI-tools/crewAI-tools/tests/base_tool_test.py:19: PydanticDeprecatedSince20: The `schema` method is deprecated; use `model_json_schema` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
```
