### PR TITLE
feat: add support for parsing actions list from environment variables

### DIFF
--- a/tests/tools/crewai_enterprise_tools_test.py
+++ b/tests/tools/crewai_enterprise_tools_test.py
@@ -74,13 +74,15 @@ class TestCrewaiEnterpriseTools(unittest.TestCase):
         CrewaiEnterpriseTools(enterprise_token="")
         self.MockAdapter.assert_called_once_with(enterprise_action_token="env-token")
 
-    @patch.dict(os.environ, {"CREWAI_ENTERPRISE_TOOLS_TOKEN": "env-token"})
+    @patch.dict(
+        os.environ,
+        {
+            "CREWAI_ENTERPRISE_TOOLS_TOKEN": "env-token",
+            "CREWAI_ENTERPRISE_TOOLS_ACTIONS_LIST": '["tool1", "tool3"]',
+        },
+    )
     def test_uses_environment_actions_list(self):
-        with patch.dict(
-            os.environ,
-            {"CREWAI_ENTERPRISE_TOOLS_ACTIONS_LIST": '["tool1", "tool3"]'},
-        ):
-            tools = CrewaiEnterpriseTools()
-            self.assertEqual(len(tools), 2)
-            self.assertEqual(tools[0].name, "tool1")
-            self.assertEqual(tools[1].name, "tool3")
+        tools = CrewaiEnterpriseTools()
+        self.assertEqual(len(tools), 2)
+        self.assertEqual(tools[0].name, "tool1")
+        self.assertEqual(tools[1].name, "tool3")

--- a/tests/tools/crewai_enterprise_tools_test.py
+++ b/tests/tools/crewai_enterprise_tools_test.py
@@ -73,3 +73,14 @@ class TestCrewaiEnterpriseTools(unittest.TestCase):
     def test_uses_environment_token_when_no_token_provided(self):
         CrewaiEnterpriseTools(enterprise_token="")
         self.MockAdapter.assert_called_once_with(enterprise_action_token="env-token")
+
+    @patch.dict(os.environ, {"CREWAI_ENTERPRISE_TOOLS_TOKEN": "env-token"})
+    def test_uses_environment_actions_list(self):
+        with patch.dict(
+            os.environ,
+            {"CREWAI_ENTERPRISE_TOOLS_ACTIONS_LIST": '["tool1", "tool3"]'},
+        ):
+            tools = CrewaiEnterpriseTools()
+            self.assertEqual(len(tools), 2)
+            self.assertEqual(tools[0].name, "tool1")
+            self.assertEqual(tools[1].name, "tool3")


### PR DESCRIPTION
This commit introduces a new function, _parse_actions_list, to handle the parsing of a string representation of a list of tool names from environment variables. The CrewaiEnterpriseTools now utilizes this function to filter tools based on the parsed actions list, enhancing flexibility in tool selection. Additionally, a new test case is added to verify the correct usage of the environment actions list.