### PR TITLE
Use environment variable to initialize `scrapegraph_py.Client`

### DIFF
--- a/crewai_tools/tools/scrapegraph_scrape_tool/scrapegraph_scrape_tool.py
+++ b/crewai_tools/tools/scrapegraph_scrape_tool/scrapegraph_scrape_tool.py
@@ -102,9 +102,8 @@ class ScrapegraphScrapeTool(BaseTool):
                     "`scrapegraph-py` package not found, please run `uv add scrapegraph-py`"
                 )
 
-        self._client = Client(api_key=api_key)
-
         self.api_key = api_key or os.getenv("SCRAPEGRAPH_API_KEY")
+        self._client = Client(api_key=self.api_key)
 
         if not self.api_key:
             raise ValueError("Scrapegraph API key is required")


### PR DESCRIPTION
This commit fixes a bug where `SCRAPEGRAPH_API_KEY` was never used to initialize `scrapegraph_py.Client`.