### PR TITLE
chore: bump version to 0.51.1 in pyproject.toml and uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crewai-tools"
-version = "0.51.0"
+version = "0.51.1"
 description = "Set of tools for the crewAI framework"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ wheels = [
 
 [[package]]
 name = "crewai-tools"
-version = "0.51.0"
+version = "0.51.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
- Updated crewai-tools version from 0.51.0 to 0.51.1 in both pyproject.toml and uv.lock.