### PR TITLE
Allow Configuring mcp `connect_timeout` and `client_session_timeout_seconds`

### DIFF
--- a/crewai_tools/adapters/mcp_adapter.py
+++ b/crewai_tools/adapters/mcp_adapter.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
 from datetime import timedelta
+from typing import TYPE_CHECKING, Any
 
 from crewai.tools import BaseTool
+
 from crewai_tools.adapters.tool_collection import ToolCollection
 
 """

--- a/crewai_tools/adapters/mcp_adapter.py
+++ b/crewai_tools/adapters/mcp_adapter.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any
+from datetime import timedelta
 
 from crewai.tools import BaseTool
 from crewai_tools.adapters.tool_collection import ToolCollection
+
 """
 MCPServer for CrewAI.
 
@@ -70,6 +72,8 @@ class MCPServerAdapter:
         self,
         serverparams: StdioServerParameters | dict[str, Any],
         *tool_names: str,
+        connect_timeout: int = 30,
+        client_session_timeout_seconds: float | timedelta | None = 5,
     ):
         """Initialize the MCP Server
 
@@ -78,6 +82,8 @@ class MCPServerAdapter:
                 `StdioServerParameters` or a `dict` respectively for STDIO and SSE.
             *tool_names: Optional names of tools to filter. If provided, only tools with
                 matching names will be available.
+            connect_timeout: Timeout for connecting to the MCP server (default: 30 seconds).
+            client_session_timeout_seconds: Timeout for client sessions (default: 5 seconds).
 
         """
 
@@ -106,7 +112,12 @@ class MCPServerAdapter:
 
         try:
             self._serverparams = serverparams
-            self._adapter = MCPAdapt(self._serverparams, CrewAIAdapter())
+            self._adapter = MCPAdapt(
+                self._serverparams,
+                CrewAIAdapter(),
+                connect_timeout=connect_timeout,
+                client_session_timeout_seconds=client_session_timeout_seconds,
+            )
             self.start()
 
         except Exception as e:

--- a/tests/adapters/mcp_adapter_test.py
+++ b/tests/adapters/mcp_adapter_test.py
@@ -1,11 +1,12 @@
+from datetime import timedelta
 from textwrap import dedent
 
 import pytest
-from datetime import timedelta
 from mcp import StdioServerParameters
 
 from crewai_tools import MCPServerAdapter
 from crewai_tools.adapters.tool_collection import ToolCollection
+
 
 @pytest.fixture
 def echo_server_script():
@@ -84,7 +85,8 @@ def test_context_manager_syntax(echo_server_script):
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "calc_tool"
         assert tools[0].run(text="hello") == "Echo: hello"
-        assert tools[1].run(a=5, b=3) == '8'
+        assert tools[1].run(a=5, b=3) == "8"
+
 
 def test_context_manager_syntax_sse(echo_sse_server):
     sse_serverparams = echo_sse_server
@@ -93,7 +95,8 @@ def test_context_manager_syntax_sse(echo_sse_server):
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "calc_tool"
         assert tools[0].run(text="hello") == "Echo: hello"
-        assert tools[1].run(a=5, b=3) == '8'
+        assert tools[1].run(a=5, b=3) == "8"
+
 
 def test_try_finally_syntax(echo_server_script):
     serverparams = StdioServerParameters(
@@ -106,9 +109,10 @@ def test_try_finally_syntax(echo_server_script):
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "calc_tool"
         assert tools[0].run(text="hello") == "Echo: hello"
-        assert tools[1].run(a=5, b=3) == '8'
+        assert tools[1].run(a=5, b=3) == "8"
     finally:
         mcp_server_adapter.stop()
+
 
 def test_try_finally_syntax_sse(echo_sse_server):
     sse_serverparams = echo_sse_server
@@ -119,9 +123,10 @@ def test_try_finally_syntax_sse(echo_sse_server):
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "calc_tool"
         assert tools[0].run(text="hello") == "Echo: hello"
-        assert tools[1].run(a=5, b=3) == '8'
+        assert tools[1].run(a=5, b=3) == "8"
     finally:
         mcp_server_adapter.stop()
+
 
 def test_context_manager_with_filtered_tools(echo_server_script):
     serverparams = StdioServerParameters(
@@ -139,6 +144,7 @@ def test_context_manager_with_filtered_tools(echo_server_script):
         with pytest.raises(KeyError):
             _ = tools["calc_tool"]
 
+
 def test_context_manager_sse_with_filtered_tools(echo_sse_server):
     sse_serverparams = echo_sse_server
     # Only select the calc_tool
@@ -146,12 +152,13 @@ def test_context_manager_sse_with_filtered_tools(echo_sse_server):
         assert isinstance(tools, ToolCollection)
         assert len(tools) == 1
         assert tools[0].name == "calc_tool"
-        assert tools[0].run(a=10, b=5) == '15'
+        assert tools[0].run(a=10, b=5) == "15"
         # Check that echo_tool is not present
         with pytest.raises(IndexError):
             _ = tools[1]
         with pytest.raises(KeyError):
             _ = tools["echo_tool"]
+
 
 def test_try_finally_with_filtered_tools(echo_server_script):
     serverparams = StdioServerParameters(
@@ -169,6 +176,7 @@ def test_try_finally_with_filtered_tools(echo_server_script):
     finally:
         mcp_server_adapter.stop()
 
+
 def test_filter_with_nonexistent_tool(echo_server_script):
     serverparams = StdioServerParameters(
         command="uv", args=["run", "python", "-c", echo_server_script]
@@ -178,6 +186,7 @@ def test_filter_with_nonexistent_tool(echo_server_script):
         # Only echo_tool should be in the result
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
+
 
 def test_filter_with_only_nonexistent_tools(echo_server_script):
     serverparams = StdioServerParameters(
@@ -192,7 +201,6 @@ def test_filter_with_only_nonexistent_tools(echo_server_script):
 
 def test_timeout_parameters_are_set(echo_server_script):
     """Test that connect_timeout and client_session_timeout_seconds are properly set."""
-    from datetime import timedelta
 
     serverparams = StdioServerParameters(
         command="uv", args=["run", "python", "-c", echo_server_script]


### PR DESCRIPTION
The`MCPAdapt` class supports configuring of connect_timeout and session_timeout as shown here: https://github.com/grll/mcpadapt/blob/main/src/mcpadapt/core.py#L172

However, these were not exposed in the `MCPAdapter` so it was not possible to configure these when using with CrewAI.

This PR allows configuration of those parameters.


**Note**: The black/isort linting automatically fixed a few other lines in existing tests in `mcp_adapter_test.py`. Can revert these if not required.