### PR TITLE
feat(init): add TavilySearchTool and TavilyExtractorTool to crewai_tools __init__

### DIFF
--- a/crewai_tools/__init__.py
+++ b/crewai_tools/__init__.py
@@ -78,4 +78,6 @@ from .tools import (
     YoutubeChannelSearchTool,
     YoutubeVideoSearchTool,
     ZapierActionTools,
+    TavilySearchTool,
+    TavilyExtractorTool,
 )

--- a/crewai_tools/tools/__init__.py
+++ b/crewai_tools/tools/__init__.py
@@ -96,3 +96,5 @@ from .youtube_channel_search_tool.youtube_channel_search_tool import (
 )
 from .youtube_video_search_tool.youtube_video_search_tool import YoutubeVideoSearchTool
 from .zapier_action_tool.zapier_action_tool import ZapierActionTools
+from .tavily_search_tool.tavily_search_tool import TavilySearchTool
+from .tavily_extractor_tool.tavily_extractor_tool import TavilyExtractorTool


### PR DESCRIPTION
This PR makes TavilySearchTool and TavilyExtractorTool available for direct import from the top-level crewai_tools package:

```py
from crewai_tools import TavilySearchTool, TavilyExtractorTool
```

- Adds the two new tool classes to crewai_tools/init.py
- Updates all so they show up in IDE autocompletion