### PR TITLE
Fix MongoDBVectorSearchTool serialization and schema

### DIFF
--- a/crewai_tools/tools/mongodb_vector_search_tool/vector_search.py
+++ b/crewai_tools/tools/mongodb_vector_search_tool/vector_search.py
@@ -45,7 +45,7 @@ class MongoDBVectorSearchConfig(BaseModel):
     )
 
 
-class MongoDBToolSchema(MongoDBVectorSearchConfig):
+class MongoDBToolSchema(BaseModel):
     """Input for MongoDBTool."""
 
     query: str = Field(

--- a/crewai_tools/tools/mongodb_vector_search_tool/vector_search.py
+++ b/crewai_tools/tools/mongodb_vector_search_tool/vector_search.py
@@ -1,4 +1,3 @@
-import json
 import os
 from importlib.metadata import version
 from logging import getLogger
@@ -264,6 +263,8 @@ class MongoDBVectorSearchTool(BaseTool):
         return [str(_id) for _id in result.upserted_ids.values()]
 
     def _run(self, query: str) -> str:
+        from bson import json_util
+
         try:
             query_config = self.query_config or MongoDBVectorSearchConfig()
             limit = query_config.limit
@@ -306,7 +307,7 @@ class MongoDBVectorSearchTool(BaseTool):
             # Format
             for doc in cursor:
                 docs.append(doc)
-            return json.dumps(docs)
+            return json_util.dumps(docs)
         except Exception as e:
             logger.error(f"Error: {e}")
             return ""


### PR DESCRIPTION
We noticed two problems in testing:

- BSON ObjectIds are not serializable, so we need to use the bson dumps
- We had made a change in #319 to make `query` the only valid parameter but I had forgotten to update the base class, so the tool was using other parameters like `limit`

I tested these changes in our integration testing pipeline