### PR TITLE
fix(tools): Prevent crash in non-interactive environments

### DIFF
--- a/crewai_tools/adapters/mcp_adapter.py
+++ b/crewai_tools/adapters/mcp_adapter.py
@@ -5,11 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from crewai.tools import BaseTool
 from crewai_tools.adapters.tool_collection import ToolCollection
-"""
-MCPServer for CrewAI.
 
-
-"""
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -29,41 +25,24 @@ except ImportError:
 
 
 class MCPServerAdapter:
-    """Manages the lifecycle of an MCP server and make its tools available to CrewAI.
+    """Manages the lifecycle of an MCP server and makes its tools available to CrewAI.
 
-    Note: tools can only be accessed after the server has been started with the
-        `start()` method.
+    This adapter handles starting and stopping the MCP server, converting its
+    capabilities into CrewAI tools. It is best used as a context manager (`with`
+    statement) to ensure resources are properly cleaned up.
 
     Attributes:
-        tools: The CrewAI tools available from the MCP server.
+        tools: A ToolCollection of the available CrewAI tools. Accessing this
+               before the server is ready will raise a ValueError.
 
-    Usage:
-        # context manager + stdio
-        with MCPServerAdapter(...) as tools:
-            # tools is now available
-
-        # context manager + sse
-        with MCPServerAdapter({"url": "http://localhost:8000/sse"}) as tools:
-            # tools is now available
-
-        # context manager with filtered tools
-        with MCPServerAdapter(..., "tool1", "tool2") as filtered_tools:
-            # only tool1 and tool2 are available
-
-        # manually stop mcp server
-        try:
-            mcp_server = MCPServerAdapter(...)
-            tools = mcp_server.tools  # all tools
-
-            # or with filtered tools
-            mcp_server = MCPServerAdapter(..., "tool1", "tool2")
-            filtered_tools = mcp_server.tools  # only tool1 and tool2
-            ...
-        finally:
-            mcp_server.stop()
-
-        # Best practice is ensure cleanup is done after use.
-        mcp_server.stop() # run after crew().kickoff()
+    Example:
+        # This is a minimal runnable example assuming an MCP server is running.
+        # from your_agent_file import your_agent, your_task
+        #
+        # server_params = {"url": "http://localhost:6006/sse"}
+        # with MCPServerAdapter(server_params) as mcp_tools:
+        #     your_agent.tools = mcp_tools
+        #     result = your_agent.kickoff(your_task)
     """
 
     def __init__(
@@ -71,59 +50,65 @@ class MCPServerAdapter:
         serverparams: StdioServerParameters | dict[str, Any],
         *tool_names: str,
     ):
-        """Initialize the MCP Server
+        """Initialize and start the MCP Server.
 
         Args:
-            serverparams: The parameters for the MCP server it supports either a
-                `StdioServerParameters` or a `dict` respectively for STDIO and SSE.
+            serverparams: The parameters for the MCP server. This supports either a
+                `StdioServerParameters` object for STDIO or a `dict` for SSE connections.
             *tool_names: Optional names of tools to filter. If provided, only tools with
                 matching names will be available.
-
         """
-
-        super().__init__()
         self._adapter = None
         self._tools = None
         self._tool_names = list(tool_names) if tool_names else None
 
         if not MCP_AVAILABLE:
-            import click
-
-            if click.confirm(
-                "You are missing the 'mcp' package. Would you like to install it?"
-            ):
-                import subprocess
-
-                try:
-                    subprocess.run(["uv", "add", "mcp crewai-tools[mcp]"], check=True)
-
-                except subprocess.CalledProcessError:
-                    raise ImportError("Failed to install mcp package")
-            else:
-                raise ImportError(
-                    "`mcp` package not found, please run `uv add crewai-tools[mcp]`"
-                )
+            msg = (
+                "❌ MCP is not available. The 'mcp' package, a required dependency, "
+                "must be installed for MCPServerAdapter to work."
+            )
+            logger.critical(msg)
+            raise ImportError(
+                "`mcp` package not found. Please install it with:\n"
+                "  pip install mcp crewai-tools[mcp]"
+            )
 
         try:
             self._serverparams = serverparams
             self._adapter = MCPAdapt(self._serverparams, CrewAIAdapter())
             self.start()
-
         except Exception as e:
+            logger.exception("Failed to initialize MCP Adapter during __init__.")
             if self._adapter is not None:
                 try:
                     self.stop()
                 except Exception as stop_e:
-                    logger.error(f"Error during stop cleanup: {stop_e}")
+                    logger.error(f"Error during post-failure cleanup: {stop_e}")
             raise RuntimeError(f"Failed to initialize MCP Adapter: {e}") from e
 
     def start(self):
         """Start the MCP server and initialize the tools."""
+        if not self._adapter:
+            raise RuntimeError("Cannot start MCP server: Adapter is not initialized.")
+        if self._tools:
+            logger.debug("MCP server already started.")
+            return
         self._tools = self._adapter.__enter__()
 
     def stop(self):
-        """Stop the MCP server"""
-        self._adapter.__exit__(None, None, None)
+        """Stop the MCP server and release all associated resources.
+
+        This method is idempotent; calling it multiple times has no effect.
+        """
+        if not self._adapter:
+            logger.debug("stop() called but adapter is already stopped.")
+            return
+
+        try:
+            self._adapter.__exit__(None, None, None)
+        finally:
+            self._tools = None
+            self._adapter = None
 
     @property
     def tools(self) -> ToolCollection[BaseTool]:
@@ -133,11 +118,11 @@ class MCPServerAdapter:
             ValueError: If the MCP server is not started.
 
         Returns:
-            The CrewAI tools available from the MCP server.
+            A ToolCollection of the available CrewAI tools.
         """
         if self._tools is None:
             raise ValueError(
-                "MCP server not started, run `mcp_server.start()` first before accessing `tools`"
+                "MCP tools are not available. The server may be stopped or initialization failed."
             )
 
         tools_collection = ToolCollection(self._tools)
@@ -146,12 +131,25 @@ class MCPServerAdapter:
         return tools_collection
 
     def __enter__(self):
-        """
-        Enter the context manager. Note that `__init__()` already starts the MCP server.
-        So tools should already be available.
-        """
+        """Enter the context manager, returning the initialized tools."""
         return self.tools
 
     def __exit__(self, exc_type, exc_value, traceback):
-        """Exit the context manager."""
-        return self._adapter.__exit__(exc_type, exc_value, traceback)
+        """Exit the context manager, stop the server, and do not suppress exceptions."""
+        self.stop()
+        return False  # Ensures any exceptions that occurred are re-raised.
+
+    def __del__(self):
+        """
+        Finalizer to attempt cleanup if the user forgets to call stop() or use a
+        context manager.
+
+        Note: This is a fallback and should not be relied upon, as Python does
+        not guarantee __del__ will always be called on object destruction.
+        """
+        if self._adapter:
+            logger.warning(
+                "MCPServerAdapter was not cleanly shut down. Please use a "
+                "context manager (`with` statement) or call .stop() explicitly."
+            )
+            self.stop()

--- a/tests/adapters/mcp_adapter_test.py
+++ b/tests/adapters/mcp_adapter_test.py
@@ -6,49 +6,50 @@ from mcp import StdioServerParameters
 from crewai_tools import MCPServerAdapter
 from crewai_tools.adapters.tool_collection import ToolCollection
 
+
 @pytest.fixture
 def echo_server_script():
     return dedent(
-        '''
+        """
         from mcp.server.fastmcp import FastMCP
 
         mcp = FastMCP("Echo Server")
 
         @mcp.tool()
         def echo_tool(text: str) -> str:
-            """Echo the input text"""
+            \"\"\"Echo the input text\"\"\"
             return f"Echo: {text}"
 
         @mcp.tool()
         def calc_tool(a: int, b: int) -> int:
-            """Calculate a + b"""
+            \"\"\"Calculate a + b\"\"\"
             return a + b
 
         mcp.run()
-        '''
+        """
     )
 
 
 @pytest.fixture
 def echo_server_sse_script():
     return dedent(
-        '''
+        """
         from mcp.server.fastmcp import FastMCP
 
         mcp = FastMCP("Echo Server", host="127.0.0.1", port=8000)
 
         @mcp.tool()
         def echo_tool(text: str) -> str:
-            """Echo the input text"""
+            \"\"\"Echo the input text\"\"\"
             return f"Echo: {text}"
 
         @mcp.tool()
         def calc_tool(a: int, b: int) -> int:
-            """Calculate a + b"""
+            \"\"\"Calculate a + b\"\"\"
             return a + b
 
         mcp.run("sse")
-        '''
+        """
     )
 
 
@@ -75,7 +76,7 @@ def echo_sse_server(echo_server_sse_script):
 
 def test_context_manager_syntax(echo_server_script):
     serverparams = StdioServerParameters(
-        command="uv", args=["run", "python", "-c", echo_server_script]
+        command="python", args=["-c", echo_server_script]
     )
     with MCPServerAdapter(serverparams) as tools:
         assert isinstance(tools, ToolCollection)
@@ -83,7 +84,8 @@ def test_context_manager_syntax(echo_server_script):
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "calc_tool"
         assert tools[0].run(text="hello") == "Echo: hello"
-        assert tools[1].run(a=5, b=3) == '8'
+        assert tools[1].run(a=5, b=3) == "8"
+
 
 def test_context_manager_syntax_sse(echo_sse_server):
     sse_serverparams = echo_sse_server
@@ -92,12 +94,14 @@ def test_context_manager_syntax_sse(echo_sse_server):
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "calc_tool"
         assert tools[0].run(text="hello") == "Echo: hello"
-        assert tools[1].run(a=5, b=3) == '8'
+        assert tools[1].run(a=5, b=3) == "8"
+
 
 def test_try_finally_syntax(echo_server_script):
     serverparams = StdioServerParameters(
-        command="uv", args=["run", "python", "-c", echo_server_script]
+        command="python", args=["-c", echo_server_script]
     )
+    mcp_server_adapter = None  # Define before try block
     try:
         mcp_server_adapter = MCPServerAdapter(serverparams)
         tools = mcp_server_adapter.tools
@@ -105,9 +109,11 @@ def test_try_finally_syntax(echo_server_script):
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "calc_tool"
         assert tools[0].run(text="hello") == "Echo: hello"
-        assert tools[1].run(a=5, b=3) == '8'
+        assert tools[1].run(a=5, b=3) == "8"
     finally:
-        mcp_server_adapter.stop()
+        if mcp_server_adapter:
+            mcp_server_adapter.stop()
+
 
 def test_try_finally_syntax_sse(echo_sse_server):
     sse_serverparams = echo_sse_server
@@ -118,13 +124,14 @@ def test_try_finally_syntax_sse(echo_sse_server):
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "calc_tool"
         assert tools[0].run(text="hello") == "Echo: hello"
-        assert tools[1].run(a=5, b=3) == '8'
+        assert tools[1].run(a=5, b=3) == "8"
     finally:
         mcp_server_adapter.stop()
 
+
 def test_context_manager_with_filtered_tools(echo_server_script):
     serverparams = StdioServerParameters(
-        command="uv", args=["run", "python", "-c", echo_server_script]
+        command="python", args=["-c", echo_server_script]
     )
     # Only select the echo_tool
     with MCPServerAdapter(serverparams, "echo_tool") as tools:
@@ -138,6 +145,7 @@ def test_context_manager_with_filtered_tools(echo_server_script):
         with pytest.raises(KeyError):
             _ = tools["calc_tool"]
 
+
 def test_context_manager_sse_with_filtered_tools(echo_sse_server):
     sse_serverparams = echo_sse_server
     # Only select the calc_tool
@@ -145,17 +153,19 @@ def test_context_manager_sse_with_filtered_tools(echo_sse_server):
         assert isinstance(tools, ToolCollection)
         assert len(tools) == 1
         assert tools[0].name == "calc_tool"
-        assert tools[0].run(a=10, b=5) == '15'
+        assert tools[0].run(a=10, b=5) == "15"
         # Check that echo_tool is not present
         with pytest.raises(IndexError):
             _ = tools[1]
         with pytest.raises(KeyError):
             _ = tools["echo_tool"]
 
+
 def test_try_finally_with_filtered_tools(echo_server_script):
     serverparams = StdioServerParameters(
-        command="uv", args=["run", "python", "-c", echo_server_script]
+        command="python", args=["-c", echo_server_script]
     )
+    mcp_server_adapter = None # Define before try block
     try:
         # Select both tools but in reverse order
         mcp_server_adapter = MCPServerAdapter(serverparams, "calc_tool", "echo_tool")
@@ -166,11 +176,13 @@ def test_try_finally_with_filtered_tools(echo_server_script):
         assert tools[0].name == "calc_tool"
         assert tools[1].name == "echo_tool"
     finally:
-        mcp_server_adapter.stop()
+        if mcp_server_adapter:
+            mcp_server_adapter.stop()
+
 
 def test_filter_with_nonexistent_tool(echo_server_script):
     serverparams = StdioServerParameters(
-        command="uv", args=["run", "python", "-c", echo_server_script]
+        command="python", args=["-c", echo_server_script]
     )
     # Include a tool that doesn't exist
     with MCPServerAdapter(serverparams, "echo_tool", "nonexistent_tool") as tools:
@@ -178,12 +190,27 @@ def test_filter_with_nonexistent_tool(echo_server_script):
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
 
+
 def test_filter_with_only_nonexistent_tools(echo_server_script):
     serverparams = StdioServerParameters(
-        command="uv", args=["run", "python", "-c", echo_server_script]
+        command="python", args=["-c", echo_server_script]
     )
     # All requested tools don't exist
     with MCPServerAdapter(serverparams, "nonexistent1", "nonexistent2") as tools:
         # Should return an empty tool collection
         assert isinstance(tools, ToolCollection)
         assert len(tools) == 0
+
+
+def test_adapter_raises_import_error_if_mcp_is_missing(monkeypatch):
+    """
+    Tests that MCPServerAdapter raises ImportError if the mcp package is not available.
+    """
+    # 1. Simulate the condition where 'mcp' is not installed by setting the
+    #    MCP_AVAILABLE flag to False in the adapter's module.
+    monkeypatch.setattr("crewai_tools.adapters.mcp_adapter.MCP_AVAILABLE", False)
+
+    # 2. Assert that instantiating the adapter under this condition raises an
+    #    ImportError with our specific error message.
+    with pytest.raises(ImportError, match="`mcp` package not found"):
+        MCPServerAdapter(serverparams={})


### PR DESCRIPTION
Fixes #3163

## Title

fix(tools): Harden MCPServerAdapter initialization and fix tests

## Description

### Summary

This pull request resolves an issue where the `MCPServerAdapter` would crash in non-interactive environments. It hardens the adapter's initialization logic, adds explicit test coverage for missing dependencies, and fixes existing bugs in the test suite itself.

### Changes Made

1.  **Hardened `MCPServerAdapter`:**
    -   Replaced the interactive `click.confirm()` prompt with a non-interactive `ImportError` to prevent crashes.
    -   Added `critical` level logging for missing dependencies.
    -   Improved the `stop()` method to be fully idempotent and to ensure all resources are released.

2.  **Fixed the Test Suite:**
    -   Resolved a `ModuleNotFoundError` in the test suite's subprocesses by changing the test command from `uv run` to `python`. This fixed 6 failing integration tests.

3.  **Added New Test Coverage:**
    -   A new unit test now confirms that an `ImportError` is correctly raised if the `mcp` package is missing.

### Motivation

-   Prevents fatal crashes in production environments (e.g., FastAPI, Docker).
-   Strengthens the reliability and maintainability of the adapter.
-   Improves the stability of the project's own test suite.

### Checklist

-   [x] Code is formatted (`ruff format .`)
-   [x] Lint checks pass (`ruff check .`)
-   [x] All local tests pass (`pytest`)

### Impact

- No breaking changes; improves error handling and test robustness only.

## How to Test

```
pytest tests/adapters/mcp_adapter_test.py
```