### PR TITLE
fix(exa): Ensure content parameter is effective in EXASearchTool

### DIFF
--- a/crewai_tools/tools/exa_tools/exa_search_tool.py
+++ b/crewai_tools/tools/exa_tools/exa_search_tool.py
@@ -95,6 +95,7 @@ class EXASearchTool(BaseTool):
             search_params["include_domains"] = include_domains
 
         if self.content:
+            search_params["text"] = True
             results = self.client.search_and_contents(
                 search_query, summary=self.summary, **search_params
             )


### PR DESCRIPTION
This change ensures that the `content` parameter is effective in `EXASearchTool` by setting `search_params["text"] = True` when `self.content` is True.

This is based on the Exa API documentation: https://docs.exa.ai/reference/search