### PR TITLE
fix(tools): firecrawl-py no more accepts params kwargs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ multion = [
     "multion>=1.1.0",
 ]
 firecrawl-py = [
-    "firecrawl-py>=1.8.0",
+    "firecrawl-py>=1.8.0,<2.0.0",
 ]
 composio-core = [
     "composio-core>=0.6.11.post1",


### PR DESCRIPTION
Tools `firecrawl_crawl_website_tool`, `firecrawl_scrape_website_tool`, `firecrawl_search_tool` are passing `params` to firecrawl Python SDK.

https://github.com/crewAIInc/crewAI-tools/blob/d02d367130c01a92bdec4e4b18e991cdda1805ee/crewai_tools/tools/firecrawl_scrape_website_tool/firecrawl_scrape_website_tool.py#L90

https://github.com/crewAIInc/crewAI-tools/blob/d02d367130c01a92bdec4e4b18e991cdda1805ee/crewai_tools/tools/firecrawl_crawl_website_tool/firecrawl_crawl_website_tool.py#L102

https://github.com/crewAIInc/crewAI-tools/blob/d02d367130c01a92bdec4e4b18e991cdda1805ee/crewai_tools/tools/firecrawl_search_tool/firecrawl_search_tool.py#L102-L105

This kwarg has been deprecated since firecrawl-py 2.0.0 for `crawl` and `scrape`, see

https://github.com/mendableai/firecrawl/commit/29b36c5f9aafa6b5bd63100cc09c5edc786cd4a6#diff-483c8de2767d25d6782630bce6706f6a8f3351729762c80b88ba21f93fe1be56

and also for `search` for now, see

https://github.com/mendableai/firecrawl/blob/8b89470f3c817a24e5e8788c3b7ea2d31acc0c50/apps/python-sdk/firecrawl/firecrawl.py#L611-L623

I would suggest restrict firecrawl-py to <2.0.0 in optional dependencies. Otherwise the tool call results in Tool Error like

```
Tool Usage Failed
Name: Firecrawl web scrape tool
Error: Unsupported parameter(s) for scrape_url: params. Please refer to the API documentation for the correct parameters.
Tool Args:
```