### PR TITLE
fix: use json_schema_extra instead of deprecated Field extra args

### DIFF
--- a/crewai_tools/tools/exa_tools/exa_search_tool.py
+++ b/crewai_tools/tools/exa_tools/exa_search_tool.py
@@ -1,7 +1,8 @@
-from typing import Any, Optional, Type, List
-from pydantic import BaseModel, Field
-from crewai.tools import BaseTool, EnvVar
 import os
+from typing import Any, List, Optional, Type
+
+from crewai.tools import BaseTool, EnvVar
+from pydantic import BaseModel, Field
 
 try:
     from exa_py import Exa
@@ -38,10 +39,14 @@ class EXASearchTool(BaseTool):
     type: Optional[str] = "auto"
     package_dependencies: List[str] = ["exa_py"]
     api_key: Optional[str] = Field(
-        default_factory=lambda: os.getenv("EXA_API_KEY"), description="API key for Exa services", required=False
+        default_factory=lambda: os.getenv("EXA_API_KEY"),
+        description="API key for Exa services",
+        json_schema_extra={"required": False},
     )
     env_vars: List[EnvVar] = [
-        EnvVar(name="EXA_API_KEY", description="API key for Exa services", required=False),
+        EnvVar(
+            name="EXA_API_KEY", description="API key for Exa services", required=False
+        ),
     ]
 
     def __init__(

--- a/tests/tools/test_import_without_warnings.py
+++ b/tests/tools/test_import_without_warnings.py
@@ -1,0 +1,10 @@
+import pytest
+from pydantic.warnings import PydanticDeprecatedSince20
+
+
+@pytest.mark.filterwarnings("error", category=PydanticDeprecatedSince20)
+def test_import_tools_without_pydantic_deprecation_warnings():
+    # This test is to ensure that the import of crewai_tools does not raise any Pydantic deprecation warnings.
+    import crewai_tools
+
+    assert crewai_tools


### PR DESCRIPTION
This PR fixes a Pydantic deprecation warning by moving the `required=False` parameter from the deprecated `Field` extra arguments into the `json_schema_extra` parameter, ensuring compatibility with Pydantic V2.0+ and eliminating the deprecation warning that would cause issues in future versions.