### PR TITLE
fix: replace deprecated class Config with model_config in Bright Data tools

### DIFF
--- a/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
+++ b/crewai_tools/tools/brightdata_tool/brightdata_dataset.py
@@ -4,16 +4,15 @@ from typing import Any, Dict, Optional, Type
 
 import aiohttp
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic_settings import BaseSettings
 
 class BrightDataConfig(BaseSettings):
+    model_config = ConfigDict(env_prefix="BRIGHTDATA_")
+    
     API_URL: str = "https://api.brightdata.com"
     DEFAULT_TIMEOUT: int = 600
     DEFAULT_POLLING_INTERVAL: int = 1
-    
-    class Config:
-        env_prefix = "BRIGHTDATA_"
 class BrightDataDatasetToolException(Exception):
     """Exception raised for custom error in the application."""
 

--- a/crewai_tools/tools/brightdata_tool/brightdata_serp.py
+++ b/crewai_tools/tools/brightdata_tool/brightdata_serp.py
@@ -4,13 +4,13 @@ from typing import Any, Optional, Type
 
 import requests
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic_settings import BaseSettings
 
 class BrightDataConfig(BaseSettings):
-    API_URL: str = "https://api.brightdata.com/request"    
-    class Config:
-        env_prefix = "BRIGHTDATA_"
+    model_config = ConfigDict(env_prefix="BRIGHTDATA_")
+    
+    API_URL: str = "https://api.brightdata.com/request"
 
 class BrightDataSearchToolSchema(BaseModel):
     """

--- a/crewai_tools/tools/brightdata_tool/brightdata_unlocker.py
+++ b/crewai_tools/tools/brightdata_tool/brightdata_unlocker.py
@@ -3,13 +3,13 @@ from typing import Any, Optional, Type
 
 import requests
 from crewai.tools import BaseTool
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic_settings import BaseSettings
 
 class BrightDataConfig(BaseSettings):
-    API_URL: str = "https://api.brightdata.com/request"    
-    class Config:
-        env_prefix = "BRIGHTDATA_"
+    model_config = ConfigDict(env_prefix="BRIGHTDATA_")
+    
+    API_URL: str = "https://api.brightdata.com/request"
 
 class BrightDataUnlockerToolSchema(BaseModel):
     """


### PR DESCRIPTION
Replaced deprecated Pydantic v1 class-based Config with ConfigDict in three Bright Data tools to fix deprecation warnings:
- brightdata_dataset.py
- brightdata_serp.py
- brightdata_unlocker.py