### PR TITLE
Weaviate hybrid search

### DIFF
--- a/crewai_tools/tools/weaviate_tool/vector_search.py
+++ b/crewai_tools/tools/weaviate_tool/vector_search.py
@@ -110,9 +110,10 @@ class WeaviateVectorSearchTool(BaseTool):
                 generative_config=self.generative_model,
             )
 
-        response = internal_docs.query.near_text(
+        response = internal_docs.query.hybrid(
             query=query,
             limit=self.limit,
+            alpha=self.alpha
         )
         json_response = ""
         for obj in response.objects:

--- a/crewai_tools/tools/weaviate_tool/vector_search.py
+++ b/crewai_tools/tools/weaviate_tool/vector_search.py
@@ -41,6 +41,7 @@ class WeaviateVectorSearchTool(BaseTool):
     collection_name: Optional[str] = None
     limit: Optional[int] = Field(default=3)
     headers: Optional[dict] = None
+    alpha: Optional[int] = Field(default=0.75)
     env_vars: List[EnvVar] = [
         EnvVar(name="OPENAI_API_KEY", description="OpenAI API key for embedding generation and retrieval", required=True),
     ]


### PR DESCRIPTION
Switched the functionality of the `WeaviateVectorSearchTool` to use hybrid search instead. Users can define the alpha parameter, which controls the weighting between vector and keyword search.