### PR TITLE
feat: harden unsafe pip installs in code interpreter

### DIFF
--- a/crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py
+++ b/crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py
@@ -385,8 +385,8 @@ class CodeInterpreterTool(BaseTool):
             exec_locals: dict[str, Any] = {}
             exec(code, {}, exec_locals)  # noqa: S102
             return exec_locals.get("result", "No result variable found.")
-        except Exception:
-            return "An error occurred while executing code in unsafe mode."
+        except Exception as e:
+            return f"An error occurred while executing code in unsafe mode: {type(e).__name__}: {e!s}"
 
     @staticmethod
     def _sanitize_library_requirement(library: str) -> str:

--- a/crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py
+++ b/crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py
@@ -155,7 +155,7 @@ class CodeInterpreterTool(BaseTool):
         """
         spec = importlib.util.find_spec("crewai_tools")
         if spec is None or spec.origin is None:
-            raise FileNotFoundError("Unable to locate crewai_tools package installation path.")
+            raise FileNotFoundError("Unable to locate crewai_tools package installation path.") from None
         return os.path.dirname(spec.origin)
 
     def _verify_docker_image(self) -> None:


### PR DESCRIPTION
# feat: harden unsafe pip installs in code interpreter

## Summary
- replace unsafe os.system installs in CodeInterpreterTool unsafe mode with sanitized subprocess-based pip usage
- add Requirement-based validation for dependency specs and host pip invocation helper
- expand unit tests covering sanitization, pip invocations, and error handling

## Testing
- uv run ruff check crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py tests/tools/test_code_interpreter_tool.py
- uv run mypy crewai_tools/tools/code_interpreter_tool/code_interpreter_tool.py
- uv run pytest tests/tools/test_code_interpreter_tool.py
