### PR TITLE
fix: initialize string list before conditional in BraveSearchTool

### DIFF
--- a/crewai_tools/tools/brave_search_tool/brave_search_tool.py
+++ b/crewai_tools/tools/brave_search_tool/brave_search_tool.py
@@ -91,9 +91,9 @@ class BraveSearchTool(BaseTool):
             response.raise_for_status()  # Handle non-200 responses
             results = response.json()
 
+            string = []
             if "web" in results:
                 results = results["web"]["results"]
-                string = []
                 for result in results:
                     try:
                         string.append(


### PR DESCRIPTION
## Problem
Fixes UnboundLocalError that occurs when Brave Search API returns responses without a 'web' key.

## Solution
Moves `string = []` initialization outside the conditional block (before line 95), ensuring the variable is always defined before being referenced on line 112.

## Testing
- All existing tests pass with valid API key
- Follows standard Python practice for preventing UnboundLocalError
- No breaking changes to existing functionality

## Related
This defensive fix prevents crashes on empty/malformed API responses, allowing graceful error handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize `string` before the `"web" in results` check to ensure it's defined even when `web` is absent.
> 
> - **BraveSearchTool (`crewai_tools/tools/brave_search_tool/brave_search_tool.py`)**:
>   - Initialize `string = []` before checking for `results["web"]` and remove duplicate init inside the block, preventing `UnboundLocalError` when `web` is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 769914b192e8be2621cf82d56b195e1a26b70ec9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->