### PR TITLE
Fixed the issue - limit parameter not working in QdrantVectorSearchTool

### DIFF
--- a/crewai_tools/tools/qdrant_vector_search_tool/qdrant_search_tool.py
+++ b/crewai_tools/tools/qdrant_vector_search_tool/qdrant_search_tool.py
@@ -152,11 +152,11 @@ class QdrantVectorSearchTool(BaseTool):
         # Format results similar to storage implementation
         results = []
         # Extract the list of ScoredPoint objects from the tuple
-        for point in search_results:
+        for point in search_results.points:
             result = {
-                "metadata": point[1][0].payload.get("metadata", {}),
-                "context": point[1][0].payload.get("text", ""),
-                "distance": point[1][0].score,
+                "metadata": point.payload.get("metadata", {}),
+                "context": point.payload.get("text", ""),
+                "distance": point.score,
             }
             results.append(result)
 


### PR DESCRIPTION
🩹 Fix: QdrantVectorSearchTool returns only one result when limit > 1

Root Cause:
The query_points() method returns a QueryResponse object whose points attribute holds the list of ScoredPoint results.
However, when iterating directly over the search_result object, Pydantic’s BaseModel.__iter__ yields key-value pairs (e.g. ('points', [points])).
As a result, the loop consumed only one iteration, producing a single record instead of the full result set.

Fix:
Iterate over search_result.points explicitly rather than over search_result itself:

# ❌ Before
for point in search_results:
            result = {
                "metadata": point[1][0].payload.get("metadata", {}),
                "context": point[1][0].payload.get("text", ""),
                "distance": point[1][0].score,
            }
            results.append(result)

# ✅ After
for point in search_results.points:
            result = {
                "metadata": point.payload.get("metadata", {}),
                "context": point.payload.get("text", ""),
                "distance": point.score,
            }
            results.append(result)

Outcome:
QdrantVectorSearchTool now respects the limit parameter and correctly returns all requested points.

Impact:
This fix ensures proper pagination and multi-result behavior in all vector search queries.